### PR TITLE
`SelfConsistentHubbardWorkChain`: fix `run_scf_fixed_magnetic`

### DIFF
--- a/aiida_quantumespresso_hp/workflows/hubbard.py
+++ b/aiida_quantumespresso_hp/workflows/hubbard.py
@@ -374,7 +374,7 @@ class SelfConsistentHubbardWorkChain(WorkChain):
         run with smeared occupations.
         """
         previous_workchain = self.ctx.workchains_scf[-1]
-        previous_parameters = previous_workchain.out.output_parameters
+        previous_parameters = previous_workchain.outputs.output_parameters
 
         inputs = self.get_inputs(PwBaseWorkChain, 'scf')
         inputs.pw.parameters['CONTROL']['calculation'] = 'scf'


### PR DESCRIPTION
Fixes #1 

This method had a left-over call to `.out` which was renamed in
`aiida-core==1.0.0` to `.outputs`. A test is added that now actually
calls this outline step.