### PR TITLE
`HpCalculation`: automatically mark invalidates cache

### DIFF
--- a/aiida_quantumespresso_hp/calculations/hp.py
+++ b/aiida_quantumespresso_hp/calculations/hp.py
@@ -5,10 +5,9 @@ import os
 from aiida import orm
 from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.common.utils import classproperty
-from aiida.engine import CalcJob
 from aiida.plugins import CalculationFactory
 
-from aiida_quantumespresso.calculations import _lowercase_dict, _uppercase_dict
+from aiida_quantumespresso.calculations import CalcJob, _lowercase_dict, _uppercase_dict
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
 
 PwCalculation = CalculationFactory('quantumespresso.pw')

--- a/tests/calculations/test_autoinvalidate_cache.py
+++ b/tests/calculations/test_autoinvalidate_cache.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+"""Test the automatic ``invalidates_cache`` attribute for exit codes."""
+import inspect
+import pytest
+
+from aiida.engine import CalcJob
+from aiida.plugins import CalculationFactory
+
+
+@pytest.mark.parametrize('entry_point_name', ['quantumespresso.hp'])
+def test_exit_code_invalidates_cache(entry_point_name):
+    """Test automatic ``invalidates_cache`` attribute of exit codes.
+
+    Test that the ``invalidates_cache`` attribute of exit codes is automatically set according to the status integer.
+    """
+    entry_point = CalculationFactory(entry_point_name)
+
+    if not inspect.isclass(entry_point) or not issubclass(entry_point, CalcJob):
+        return
+
+    for exit_code in entry_point.exit_codes.values():
+        if exit_code.status < 400:
+            assert exit_code.invalidates_cache
+        else:
+            assert not exit_code.invalidates_cache


### PR DESCRIPTION
Fixes #5 

By convention, exit codes with a status smaller than 400, are considered
to be unrecoverable errors. This means that these calculations should
not be considered as valid sources by the caching mechanism. This can be
signalled by setting `invalidate_cache=True` when declaring the exit
code. Instead of doing this manually for every port, since we have a
clear rule that all exit codes below 400 should have this value, this is
done in one place by using a subclass of `CalcJob` that has a subclass
of the `CalcJobProcessSpec` that automatically flips this switch based
on the exit status.

This trick is already implemented in `aiida-quantumespresso`, so the
only thing we have to do here is to subclass from the subclass
`aiida_quantumespresso.calculations.CalcJob` instead of the base class
`aiida.engine.Calcjob` that ships with `aiida-core`.