### PR TITLE
DevOps: fix the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: continuous-integration
+name: ci
 
 on: [push, pull_request]
 
@@ -23,7 +23,7 @@ jobs:
         -   name: Set up Python
             uses: actions/setup-python@v2
             with:
-                python-version: 3.8
+                python-version: '3.8'
 
         -   name: Install python dependencies
             run: pip install -e .[pre-commit,tests]
@@ -37,17 +37,9 @@ jobs:
 
         strategy:
             matrix:
-                python-version: [3.6, 3.7, 3.8]
+                python-version: ['3.6', '3.7', '3.8']
 
         services:
-            postgres:
-                image: postgres:10
-                env:
-                    POSTGRES_DB: test_${{ matrix.backend }}
-                    POSTGRES_PASSWORD: ''
-                    POSTGRES_HOST_AUTH_METHOD: trust
-                ports:
-                -    5432:5432
             rabbitmq:
                 image: rabbitmq:latest
                 ports:
@@ -71,9 +63,7 @@ jobs:
                 python-version: ${{ matrix.python-version }}
 
         -   name: Install system dependencies
-            run: |
-                sudo apt update
-                sudo apt install postgresql-10
+            run: sudo apt update && sudo apt install postgresql
 
         -   name: Install python dependencies
             run: |

--- a/setup.json
+++ b/setup.json
@@ -28,7 +28,7 @@
     "extras_require": {
         "pre-commit": [
             "pre-commit~=2.2",
-            "pylint~=2.5"
+            "pylint==2.5"
         ],
         "tests": [
             "pgtest~=1.3",


### PR DESCRIPTION
The `ubuntu-latest` image no longer supports PostgreSQL 10. The best
solution is to simply install the service through `apt` which will
simply install the latest available version.