### PR TITLE
DevOps: update pre-commit dependencies, add `isort` and `flynt`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,16 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
 
+-   repo: https://github.com/ikamensh/flynt/
+    rev: '0.76'
+    hooks:
+    -   id: flynt
+
+-   repo: https://github.com/pycqa/isort
+    rev: '5.10.1'
+    hooks:
+    -   id: isort
+
 -   repo: https://github.com/pre-commit/mirrors-yapf
     rev: 'v0.32.0'
     hooks:
@@ -34,16 +44,3 @@ repos:
         entry: pylint
         types: [python]
         language: system
-        args: [
-            '--max-line-length=120',
-            '--disable=bad-continuation',
-            '--disable=consider-using-f-string',
-            '--disable=duplicate-code',
-            '--disable=import-outside-toplevel',
-            '--disable=inconsistent-return-statements',
-            '--disable=invalid-name',
-            '--disable=no-member',
-            '--disable=too-many-arguments',
-            '--disable=too-many-branches',
-            '--disable=too-many-locals',
-        ]

--- a/aiida_quantumespresso_hp/calculations/hp.py
+++ b/aiida_quantumespresso_hp/calculations/hp.py
@@ -6,7 +6,6 @@ from aiida import orm
 from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.common.utils import classproperty
 from aiida.plugins import CalculationFactory
-
 from aiida_quantumespresso.calculations import CalcJob, _lowercase_dict, _uppercase_dict
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
 

--- a/aiida_quantumespresso_hp/cli/__init__.py
+++ b/aiida_quantumespresso_hp/cli/__init__.py
@@ -2,10 +2,9 @@
 # pylint: disable=wrong-import-position,wildcard-import
 """Module for the command line interface."""
 
+from aiida.cmdline.params import options, types
 import click
 import click_completion
-
-from aiida.cmdline.params import options, types
 
 # Activate the completion of parameter types provided by the click_completion package
 click_completion.init()

--- a/aiida_quantumespresso_hp/cli/calculations/hp.py
+++ b/aiida_quantumespresso_hp/cli/calculations/hp.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 """Command line scripts to launch a `HpCalculation` for testing and demonstration purposes."""
-import click
-
 from aiida.cmdline.params import options, types
 from aiida.cmdline.utils import decorators
-
 from aiida_quantumespresso.cli.utils import launch
 from aiida_quantumespresso.cli.utils import options as options_qe
+import click
+
 from . import cmd_launch
 
 

--- a/aiida_quantumespresso_hp/cli/workflows/hp/base.py
+++ b/aiida_quantumespresso_hp/cli/workflows/hp/base.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 """Command line scripts to launch a `HpBaseWorkChain` for testing and demonstration purposes."""
-import click
-
 from aiida.cmdline.params import options, types
 from aiida.cmdline.utils import decorators
-
 from aiida_quantumespresso.cli.utils import launch
 from aiida_quantumespresso.cli.utils import options as options_qe
+import click
+
 from .. import cmd_launch
 
 

--- a/aiida_quantumespresso_hp/cli/workflows/hp/main.py
+++ b/aiida_quantumespresso_hp/cli/workflows/hp/main.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 """Command line scripts to launch a `HpWorkChain` for testing and demonstration purposes."""
 
-import click
-
 from aiida.cmdline.params import options, types
 from aiida.cmdline.utils import decorators
-
 from aiida_quantumespresso.cli.utils import launch
 from aiida_quantumespresso.cli.utils import options as options_qe
+import click
+
 from .. import cmd_launch
 
 

--- a/aiida_quantumespresso_hp/cli/workflows/hubbard.py
+++ b/aiida_quantumespresso_hp/cli/workflows/hubbard.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 """Command line scripts to launch a `SelfConsistentHubbardWorkChain` for testing and demonstration purposes."""
-import click
-
 from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
-
-from aiida_sssp.cli import options as options_sssp
 from aiida_quantumespresso.cli.utils import launch
 from aiida_quantumespresso.cli.utils import options as options_qe
+from aiida_sssp.cli import options as options_sssp
+import click
+
 from . import cmd_launch
 
 

--- a/aiida_quantumespresso_hp/parsers/hp.py
+++ b/aiida_quantumespresso_hp/parsers/hp.py
@@ -2,13 +2,13 @@
 """Parser implementation for the `HpCalculation` plugin."""
 import os
 import re
-import numpy
 
 from aiida import orm
 from aiida.common import exceptions
 from aiida.parsers import Parser
-
 from aiida_quantumespresso.utils.mapping import get_logging_container
+import numpy
+
 from aiida_quantumespresso_hp.calculations.hp import HpCalculation
 
 

--- a/aiida_quantumespresso_hp/workflows/hp/base.py
+++ b/aiida_quantumespresso_hp/workflows/hp/base.py
@@ -2,7 +2,7 @@
 """Workchain to run a Quantum ESPRESSO hp.x calculation with automated error handling and restarts."""
 from aiida import orm
 from aiida.common import AttributeDict
-from aiida.engine import while_, BaseRestartWorkChain, process_handler, ProcessHandlerReport
+from aiida.engine import BaseRestartWorkChain, ProcessHandlerReport, process_handler, while_
 from aiida.plugins import CalculationFactory
 
 HpCalculation = CalculationFactory('quantumespresso.hp')

--- a/aiida_quantumespresso_hp/workflows/hp/main.py
+++ b/aiida_quantumespresso_hp/workflows/hp/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Work chain to run a Quantum ESPRESSO hp.x calculation."""
 from aiida import orm
-from aiida.engine import WorkChain, ToContext, if_
+from aiida.engine import ToContext, WorkChain, if_
 from aiida.plugins import WorkflowFactory
 
 HpBaseWorkChain = WorkflowFactory('quantumespresso.hp.base')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,9 @@ Source = 'https://github.com/aiidateam/aiida-quantumespresso-hp'
 
 [project.optional-dependencies]
 pre-commit = [
-    'pre-commit~=2.2',
+    'pre-commit~=2.17',
     'pylint==2.13.7',
+    'pylint-aiida~=0.1.1',
 ]
 tests = [
     'pgtest~=1.3',
@@ -68,11 +69,40 @@ exclude = [
     '.pre-commit-config.yaml',
 ]
 
+[tool.flynt]
+line-length = 120
+fail-on-change = true
+
+[tool.isort]
+force_sort_within_sections = true
+include_trailing_comma = true
+line_length = 120
+multi_line_output = 3
+
 [tool.pydocstyle]
 ignore = [
     'D104',
     'D203',
     'D213'
+]
+
+[tool.pylint.master]
+load-plugins = ['pylint_aiida']
+
+[tool.pylint.format]
+max-line-length = 120
+
+[tool.pylint.messages_control]
+disable = [
+    'bad-continuation',
+    'duplicate-code',
+    'import-outside-toplevel',
+    'inconsistent-return-statements',
+    'invalid-name',
+    'no-member',
+    'too-many-arguments',
+    'too-many-branches',
+    'too-many-locals',
 ]
 
 [tool.yapf]

--- a/tests/calculations/test_autoinvalidate_cache.py
+++ b/tests/calculations/test_autoinvalidate_cache.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """Test the automatic ``invalidates_cache`` attribute for exit codes."""
 import inspect
-import pytest
 
 from aiida.engine import CalcJob
 from aiida.plugins import CalculationFactory
+import pytest
 
 
 @pytest.mark.parametrize('entry_point_name', ['quantumespresso.hp'])

--- a/tests/calculations/test_hp.py
+++ b/tests/calculations/test_hp.py
@@ -2,11 +2,10 @@
 """Tests for the `HpCalculation` class."""
 import os
 
-import pytest
-
 from aiida import orm
 from aiida.common import datastructures
 from aiida.plugins import CalculationFactory
+import pytest
 
 HpCalculation = CalculationFactory('quantumespresso.hp')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,8 @@ import os
 import shutil
 import tempfile
 
-import pytest
 from aiida.manage.fixtures import fixture_manager
+import pytest
 
 pytest_plugins = ['aiida.manage.tests.pytest_fixtures']  # pylint: disable=invalid-name
 

--- a/tests/parsers/test_hp.py
+++ b/tests/parsers/test_hp.py
@@ -2,9 +2,9 @@
 # pylint: disable=unused-argument,redefined-outer-name
 """Tests for the `HpParser`."""
 
-import pytest
 from aiida import orm
 from aiida.common import AttributeDict
+import pytest
 
 
 @pytest.fixture

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 """Tests for the :mod:`aiida_quantumespresso_hp.utils.validation` module."""
+from aiida import orm
 import pytest
 
-from aiida import orm
 from aiida_quantumespresso_hp.utils.validation import validate_parent_calculation
 
 

--- a/tests/workflows/hp/test_base.py
+++ b/tests/workflows/hp/test_base.py
@@ -1,12 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=no-member,redefined-outer-name
 """Tests for the `HpBaseWorkChain` class."""
-import pytest
-
-from plumpy import ProcessState
-
 from aiida.common import AttributeDict
 from aiida.engine import ProcessHandlerReport
+from plumpy import ProcessState
+import pytest
 
 from aiida_quantumespresso_hp.calculations.hp import HpCalculation
 from aiida_quantumespresso_hp.workflows.hp.base import HpBaseWorkChain

--- a/tests/workflows/test_hubbard.py
+++ b/tests/workflows/test_hubbard.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=no-member,redefined-outer-name
 """Tests for the `SelfConsistentHubbardWorkChain` class."""
-import pytest
-
 from aiida.orm import Dict
+import pytest
 
 
 @pytest.fixture


### PR DESCRIPTION
Add the `isort` and `flynt` linting steps. It also updates the `pylint`
dependency. This allows to move the configuration from the
`pre-commit-config.yaml` to`pyproject.toml`.