### PR TITLE
DevOps: Update Python version requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
 
         strategy:
             matrix:
-                python-version: ['3.6', '3.7', '3.8']
+                python-version: ['3.8', '3.9']
 
         services:
             rabbitmq:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,11 @@ classifiers = [
     'Operating System :: POSIX :: Linux',
     'Operating System :: MacOS :: MacOS X',
     'Programming Language :: Python',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
 ]
 keywords = ['aiida', 'workflows']
-requires-python = '>=3.6'
+requires-python = '>=3.8'
 dependencies = [
     'aiida-core~=1.4',
     'aiida-quantumespresso~=3.0',
@@ -42,7 +41,7 @@ pre-commit = [
 ]
 tests = [
     'pgtest~=1.3',
-    'pytest~=5.4',
+    'pytest~=6.2',
     'pytest-regressions~=1.0',
 ]
 


### PR DESCRIPTION
The Python requirements are updated:

 * Drop support for Python 3.6 and Python 3.7
 * Add support for Python 3.9

To add support for Python 3.9, the minimum requirement for `pytest`
also had to be updated.