### PR TITLE
`Hubbard`: fix not overridden `max_iterations`

### DIFF
--- a/src/aiida_quantumespresso_hp/workflows/hubbard.py
+++ b/src/aiida_quantumespresso_hp/workflows/hubbard.py
@@ -116,9 +116,8 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
         )
         spec.input(
             'skip_first_relax',
-            valid_type=bool,
-            default=lambda: False,
-            non_db=True,
+            valid_type=orm.Bool,
+            default=lambda: orm.Bool(False),
             help='If True, skip the first relaxation'
         )
         spec.input(
@@ -288,9 +287,10 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
         builder.relax = relax
         builder.scf = scf
         builder.hubbard = hubbard
-        builder.skip_first_relax = inputs['skip_first_relax']
+        builder.skip_first_relax = orm.Bool(inputs['skip_first_relax'])
         builder.tolerance_onsite = orm.Float(inputs['tolerance_onsite'])
         builder.tolerance_intersite = orm.Float(inputs['tolerance_intersite'])
+        builder.max_iterations = orm.Int(inputs['max_iterations'])
         builder.meta_convergence = orm.Bool(inputs['meta_convergence'])
         builder.clean_workdir = orm.Bool(inputs['clean_workdir'])
 
@@ -305,7 +305,7 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
         self.ctx.is_insulator = None
         self.ctx.is_magnetic = False
         self.ctx.iteration = 0
-        self.ctx.skip_first_relax = self.inputs.skip_first_relax
+        self.ctx.skip_first_relax = self.inputs.skip_first_relax.value
         self.ctx.relax_frequency = 1
         if 'relax_frequency' in self.inputs:
             self.ctx.relax_frequency = self.inputs.relax_frequency.value

--- a/src/aiida_quantumespresso_hp/workflows/protocols/hubbard.yaml
+++ b/src/aiida_quantumespresso_hp/workflows/protocols/hubbard.yaml
@@ -1,5 +1,6 @@
 default_inputs:
     clean_workdir: True
+    max_iterations: 10
     meta_convergence: True
     tolerance_onsite: 0.1
     tolerance_intersite: 0.01

--- a/tests/workflows/protocols/test_hubbard.py
+++ b/tests/workflows/protocols/test_hubbard.py
@@ -33,13 +33,19 @@ def test_default(fixture_code, data_regression, generate_hubbard_structure, seri
 @pytest.mark.parametrize(
     'overrides', (
         {
-            'relax_frequency': 3
-        },
-        {
             'tolerance_onsite': 1
         },
         {
             'tolerance_intersite': 1
+        },
+        {
+            'skip_first_relax': True
+        },
+        {
+            'relax_frequency': 3
+        },
+        {
+            'max_iterations': 1
         },
         {
             'meta_convergence': False

--- a/tests/workflows/protocols/test_hubbard/test_default.yml
+++ b/tests/workflows/protocols/test_hubbard/test_default.yml
@@ -17,6 +17,7 @@ hubbard:
   parallelize_qpoints: true
   qpoints_distance: 0.8
 hubbard_structure: CoLiO2
+max_iterations: 10
 meta_convergence: true
 relax:
   base:

--- a/tests/workflows/test_hubbard.py
+++ b/tests/workflows/test_hubbard.py
@@ -164,8 +164,10 @@ def test_magnetic_setup(generate_workchain_hubbard, generate_inputs_hubbard):
 @pytest.mark.usefixtures('aiida_profile')
 def test_skip_first_relax(generate_workchain_hubbard, generate_inputs_hubbard):
     """Test `SelfConsistentHubbardWorkChain` when skipping only the first relax."""
+    from aiida.orm import Bool
+
     inputs = generate_inputs_hubbard()
-    inputs['skip_first_relax'] = True
+    inputs['skip_first_relax'] = Bool(True)
     process = generate_workchain_hubbard(inputs=inputs)
 
     process.setup()


### PR DESCRIPTION
The `max_iterations` input was not overridden.
We also change the `skip_first_relax` from `non_db` True to False, and make it storable.