### PR TITLE
Workflows: fix logic for relabeling

### DIFF
--- a/src/aiida_quantumespresso_hp/workflows/hubbard.py
+++ b/src/aiida_quantumespresso_hp/workflows/hubbard.py
@@ -633,7 +633,6 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
                 self.ctx.current_hubbard_structure = result['hubbard_structure']
                 if self.ctx.current_magnetic_moments is not None:
                     self.ctx.current_magnetic_moments = result['starting_magnetization']
-                return
 
         if not len(ref_params) == len(new_params):
             self.report('The new and old Hubbard parameters have different lenghts. Assuming to be at the first cycle.')

--- a/tests/workflows/test_hubbard.py
+++ b/tests/workflows/test_hubbard.py
@@ -357,10 +357,16 @@ def test_relabel_check_convergence(
     # Mocking current (i.e. "old") and "new" HubbardStructureData,
     # containing different Hubbard parameters
     process.ctx.current_hubbard_structure = generate_hubbard_structure()
-    process.ctx.workchains_hp = [generate_hp_workchain_node(relabel=True)]
+    process.ctx.workchains_hp = [generate_hp_workchain_node(relabel=True, u_value=100)]
 
     process.check_convergence()
     assert not process.ctx.is_converged
+
+    process.ctx.current_hubbard_structure = generate_hubbard_structure(u_value=99.99)
+    process.ctx.workchains_hp = [generate_hp_workchain_node(relabel=True, u_value=100)]
+
+    process.check_convergence()
+    assert process.ctx.is_converged
 
 
 @pytest.mark.usefixtures('aiida_profile')


### PR DESCRIPTION
The current logic avoids checking the convergence
of Hubbard parameters if relabeling is performed.
This is incorrect and it is removed.