### PR TITLE
Workflows: avoid relabeling multiple times bug

### DIFF
--- a/src/aiida_quantumespresso_hp/workflows/hubbard.py
+++ b/src/aiida_quantumespresso_hp/workflows/hubbard.py
@@ -633,6 +633,7 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
                 self.ctx.current_hubbard_structure = result['hubbard_structure']
                 if self.ctx.current_magnetic_moments is not None:
                     self.ctx.current_magnetic_moments = result['starting_magnetization']
+                break
 
         if not len(ref_params) == len(new_params):
             self.report('The new and old Hubbard parameters have different lenghts. Assuming to be at the first cycle.')


### PR DESCRIPTION
The SelfConsistentHubbardWorkChain logic had a
bug, which was relabeling the atoms multiple times.