### PR TITLE
Exit code for early stop due to Fermi shift

### DIFF
--- a/src/aiida_quantumespresso_hp/calculations/hp.py
+++ b/src/aiida_quantumespresso_hp/calculations/hp.py
@@ -183,6 +183,9 @@ class HpCalculation(CalcJob):
             message='One of the required perturbation inputs files was not found.')
         spec.exit_code(365, 'ERROR_INCORRECT_ORDER_ATOMIC_POSITIONS',
             message='The atomic positions were not sorted with Hubbard sites first.')
+        spec.exit_code(366, 'ERROR_FERMI_SHIFT',
+            message=('The code failed due to Fermi shift, probably due to low energy cutoff '
+                'or due to an incorrect treatment of an insulating state (i.e. no smearing shoudl be used).'))
 
         # Significant errors but calculation can be used to restart
         spec.exit_code(400, 'ERROR_OUT_OF_WALLTIME',

--- a/src/aiida_quantumespresso_hp/parsers/hp.py
+++ b/src/aiida_quantumespresso_hp/parsers/hp.py
@@ -135,6 +135,7 @@ class HpParser(Parser):
             'ERROR_COMPUTING_CHOLESKY',
             'ERROR_MISSING_CHI_MATRICES',
             'ERROR_INCOMPATIBLE_FFT_GRID',
+            'ERROR_FERMI_SHIFT',
         ]:
             if exit_status in logs['error']:
                 return self.exit_codes.get(exit_status)

--- a/src/aiida_quantumespresso_hp/parsers/parse_raw/hp.py
+++ b/src/aiida_quantumespresso_hp/parsers/parse_raw/hp.py
@@ -87,7 +87,8 @@ def detect_important_message(logs, line):
             'Reconstruction problem: some chi were not found': 'ERROR_MISSING_CHI_MATRICES',
             'incompatible FFT grid': 'ERROR_INCOMPATIBLE_FFT_GRID',
             REG_ERROR_CONVERGENCE_NOT_REACHED: 'ERROR_CONVERGENCE_NOT_REACHED',
-            ERROR_POSITIONS: 'ERROR_INCORRECT_ORDER_ATOMIC_POSITIONS'
+            ERROR_POSITIONS: 'ERROR_INCORRECT_ORDER_ATOMIC_POSITIONS',
+            'WARNING: The Fermi energy shift is zero or too big!': 'ERROR_FERMI_SHIFT',
         },
         'warning': {
             'Warning:': None,

--- a/tests/parsers/fixtures/hp/failed_fermi_shift/aiida.in
+++ b/tests/parsers/fixtures/hp/failed_fermi_shift/aiida.in
@@ -1,0 +1,13 @@
+&INPUTHP
+  conv_thr_chi =   1.0000000000d-06
+  determine_q_mesh_only = .true.
+  find_atpert = 3
+  iverbosity = 2
+  max_seconds =   3.4200000000d+03
+  nq1 = 4
+  nq2 = 4
+  nq3 = 4
+  outdir = 'out'
+  perturb_only_atom(13) = .true.
+  prefix = 'aiida'
+/

--- a/tests/parsers/fixtures/hp/failed_fermi_shift/aiida.out
+++ b/tests/parsers/fixtures/hp/failed_fermi_shift/aiida.out
@@ -1,0 +1,236 @@
+     Program HP v.7.2 starts on  5Jun2023 at 13:54:28 
+
+     This program is part of the open-source Quantum ESPRESSO suite
+     for quantum simulation of materials; please cite
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 21 395502 (2009);
+         "P. Giannozzi et al., J. Phys.:Condens. Matter 29 465901 (2017);
+         "P. Giannozzi et al., J. Chem. Phys. 152 154105 (2020);
+          URL http://www.quantum-espresso.org", 
+     in publications or presentations arising from this work. More details at
+     http://www.quantum-espresso.org/quote
+
+     Parallel version (MPI), running on    48 processors
+
+     MPI processes distributed on     1 nodes
+     K-points division:     npool     =      16
+     R & G space division:  proc/nbgrp/npool/nimage =       3
+     24962 MiB available memory on the printing compute node when the environment starts
+ 
+
+     =---------------------------------------------------------------------------=
+
+           Calculation of Hubbard parameters using the HP code based on DFPT      
+
+               Please cite the following papers when using this program:          
+
+                 - HP code : Comput. Phys. Commun. 279, 108455 (2022).            
+
+                 - Theory  : Phys. Rev. B 98,  085127 (2018) and                  
+
+                             Phys. Rev. B 103, 045141 (2021).                     
+
+     =-----------------------------------------------------------------------------=
+
+     Reading xml data from directory:
+
+     out/aiida.save/
+
+     IMPORTANT: XC functional enforced from input :
+     Exchange-correlation= PBESOL
+                           (   1   4  10   8   0   0   0)
+     Any further DFT definition will be discarded
+     Please, verify this is what you really want
+
+ 
+     Parallelization info
+     --------------------
+     sticks:   dense  smooth     PW     G-vecs:    dense   smooth      PW
+     Min         905     905    271                30463    30463    5034
+     Max         906     906    271                30465    30465    5035
+     Sum        2717    2717    813                91393    91393   15103
+ 
+     Using Slab Decomposition
+ 
+
+     Check: negative core charge=   -0.000036
+     Reading collected, re-writing distributed wavefunctions
+ 
+
+     bravais-lattice index     =             0
+     lattice parameter (alat)  =       12.3672 (a.u.)
+     unit-cell volume          =     1453.9300 (a.u.)^3
+     number of atoms/cell      =            16
+     number of atomic types    =             2
+     kinetic-energy cut-off    =         60.00 (Ry)
+     charge density cut-off    =        240.00 (Ry)
+     conv. thresh. for NSCF    =       1.0E-11
+     conv. thresh. for chi     =       1.0E-06
+     Input Hubbard parameters (in eV):
+       V (  1,   1)  =   5.0000
+       V (  1, 229)  =   0.0000
+       V (  1, 230)  =   0.0000
+       V (  2,   2)  =   5.0000
+       V (  2,   6)  =   0.0000
+       V (  2, 405)  =   0.0000
+       V (  3,   3)  =   5.0000
+       V (  4,   4)  =   5.0000
+       V (  5,   5)  =   0.0000
+       V (  5,  34)  =   0.0000
+       V (  5, 209)  =   0.0000
+       V (  6,   2)  =   0.0000
+       V (  6,   6)  =   0.0000
+       V (  6, 209)  =   0.0000
+       V (  7,   7)  =   0.0000
+       V (  8,   8)  =   0.0000
+       V (  9,   9)  =   0.0000
+       V ( 10,  10)  =   0.0000
+       V ( 11,  11)  =   0.0000
+       V ( 12,  12)  =   0.0000
+       V ( 13,  13)  =   0.0000
+       V ( 14,  14)  =   0.0000
+       V ( 15,  15)  =   0.0000
+       V ( 16,  16)  =   0.0000
+
+     celldm(1) = 12.36723  celldm(2) =  0.00000  celldm(3) =  0.00000
+     celldm(4) =  0.00000  celldm(5) =  0.00000  celldm(6) =  0.00000
+
+     crystal axes: (cart. coord. in units of alat)
+               a(1) = (  0.5609  0.5784  0.5924 )  
+               a(2) = (  0.5609 -0.5784 -0.5924 )  
+               a(3) = ( -0.5609  0.5784 -0.5924 )  
+
+     reciprocal axes: (cart. coord. in units 2 pi/alat)
+               b(1) = (  0.8915  0.8645  0.0000 )  
+               b(2) = (  0.8915  0.0000 -0.8440 )  
+               b(3) = (  0.0000  0.8645 -0.8440 )  
+
+     Atoms inside the unit cell (Cartesian axes):
+     site n.  atom      mass           positions (alat units)
+        1      W     183.8400   tau(  1) = ( -0.28043  0.57835 -0.55568  )
+        2      W     183.8400   tau(  2) = (  0.84128  0.00000 -0.03673  )
+        3      W     183.8400   tau(  3) = (  0.28043  0.00000 -0.55450  )
+        4      W     183.8400   tau(  4) = (  0.28043  0.57835 -0.03791  )
+        5      O      15.9994   tau(  5) = (  0.00000  0.00000  0.00000  )
+        6      O      15.9994   tau(  6) = (  0.56086  0.00000  0.00000  )
+        7      O      15.9994   tau(  7) = (  0.56086  0.57835  0.00000  )
+        8      O      15.9994   tau(  8) = (  0.00000  0.57835  0.00000  )
+        9      O      15.9994   tau(  9) = (  0.28043  0.28397  0.03317  )
+       10      O      15.9994   tau( 10) = (  0.28043  0.29438 -0.62558  )
+       11      O      15.9994   tau( 11) = ( -0.28043  0.29438 -0.55923  )
+       12      O      15.9994   tau( 12) = (  0.84128  0.28397 -0.03317  )
+       13      O      15.9994   tau( 13) = (  0.28043  0.00000 -0.87440  )
+       14      O      15.9994   tau( 14) = (  0.28043  0.57835  0.28199  )
+       15      O      15.9994   tau( 15) = (  0.28043  0.00000 -0.26540  )
+       16      O      15.9994   tau( 16) = (  0.28043  0.57835 -0.32701  )
+
+     Atom which will be perturbed:
+
+       13      O      15.9994   tau(13) = (  0.28043  0.00000 -0.87440  )
+
+     Reading xml data from directory:
+
+     out/aiida.save/
+
+     IMPORTANT: XC functional enforced from input :
+     Exchange-correlation= PBESOL
+                           (   1   4  10   8   0   0   0)
+     Any further DFT definition will be discarded
+     Please, verify this is what you really want
+
+ 
+     Parallelization info
+     --------------------
+     sticks:   dense  smooth     PW     G-vecs:    dense   smooth      PW
+     Min         905     905    271                30463    30463    5034
+     Max         906     906    271                30465    30465    5035
+     Sum        2717    2717    813                91393    91393   15103
+ 
+     Using Slab Decomposition
+ 
+
+     Check: negative core charge=   -0.000036
+     Reading collected, re-writing distributed wavefunctions
+ 
+     =====================================================================
+
+                          PERTURBED ATOM #   13
+
+     site n.  atom      mass           positions (alat units)
+       13      O      15.9994   tau(13) = (  0.28043  0.00000 -0.87440  )
+ 
+     =====================================================================
+
+     The perturbed atom has a type which is not unique!
+     Changing the type of the perturbed atom and recomputing the symmetries...
+     The number of symmetries is reduced :
+     nsym =  4  nsym_PWscf =  8
+     Changing the type of the perturbed atom back to its original type...
+
+     # Lots of lines neglected 
+
+      =--------------------------------------------=
+                 SOLVE THE LINEAR SYSTEM
+      =--------------------------------------------=
+
+      atom #  2   q point #   1   iter #   1
+
+     Pert. #  1: Fermi energy shift (Ry) =    -4.4413E+01    -2.8580E-03
+
+      WARNING: The Fermi energy shift is zero or too big!
+      This may happen in two cases:
+      1. The DOS at the Fermi level is too small:
+         DOS(E_Fermi) =   -0.3691E-05
+         This means that most likely the system has a gap,
+         and hence it should NOT be treated as a metal
+         (otherwise numerical instabilities will appear).
+      2. Numerical instabilities due to too low cutoff
+         for hard pseudopotentials.
+
+      Stopping...
+
+      Solution (for magnetic insulators):
+      Try to use the 2-step scf procedure as in HP/example02
+    
+    # Lots of lines neglected 
+
+     Called by init_run:
+
+     Called by electrons:
+     v_of_rho     :      0.17s CPU      0.21s WALL (       2 calls)
+     v_h          :      0.01s CPU      0.01s WALL (       2 calls)
+     v_xc         :      0.17s CPU      0.20s WALL (       2 calls)
+
+     Called by c_bands:
+
+     Called by sum_band:
+
+     Called by *egterg:
+
+     Called by h_psi:
+
+     General routines
+     fft          :      0.09s CPU      0.16s WALL (      22 calls)
+     davcio       :      0.00s CPU      0.02s WALL (       6 calls)
+ 
+     Parallel routines
+
+     Hubbard U routines
+     alloc_neigh  :      0.33s CPU      0.34s WALL (       2 calls)
+ 
+     init_vloc    :      0.37s CPU      0.37s WALL (       2 calls)
+     init_us_1    :      0.02s CPU      0.03s WALL (       2 calls)
+ 
+     PRINTING TIMING FROM HP ROUTINES: 
+ 
+ 
+     PRINTING TIMING FROM LR MODULE: 
+ 
+ 
+     HP           :      2.09s CPU      3.79s WALL
+
+ 
+   This run was terminated on:  13:54:32   5Jun2023            
+
+=------------------------------------------------------------------------------=
+   JOB DONE.
+=------------------------------------------------------------------------------=

--- a/tests/parsers/test_hp.py
+++ b/tests/parsers/test_hp.py
@@ -256,8 +256,9 @@ def test_hp_failed_invalid_namelist(aiida_localhost, generate_calc_job_node, gen
 @pytest.mark.parametrize(('name', 'exit_status'), (
     ('failed_no_hubbard_parameters', HpCalculation.exit_codes.ERROR_OUTPUT_HUBBARD_MISSING.status),
     ('failed_no_hubbard_chi', HpCalculation.exit_codes.ERROR_OUTPUT_HUBBARD_CHI_MISSING.status),
-    ('failed_out_of_walltime', HpCalculation.exit_codes.ERROR_OUT_OF_WALLTIME.status),
     ('failed_stdout_incomplete', HpCalculation.exit_codes.ERROR_OUTPUT_STDOUT_INCOMPLETE.status),
+    ('failed_fermi_shift', HpCalculation.exit_codes.ERROR_FERMI_SHIFT.status),
+    ('failed_out_of_walltime', HpCalculation.exit_codes.ERROR_OUT_OF_WALLTIME.status),
     ('failed_computing_cholesky', HpCalculation.exit_codes.ERROR_COMPUTING_CHOLESKY.status),
     ('failed_missing_chi_matrices', HpCalculation.exit_codes.ERROR_MISSING_CHI_MATRICES.status),
     ('failed_incompatible_fft_grid', HpCalculation.exit_codes.ERROR_INCOMPATIBLE_FFT_GRID.status),


### PR DESCRIPTION
Fixes #57

We introduce an exit code for the early stop of `hp.x` when it detects an insulator treated as a metal,
which would otherwise finish with exit status 0,
but without any actual useful data produced.

To discuss: the name for the exit code.