### PR TITLE
Tests: bump SSSP version to 1.3 and update regression

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,7 +168,7 @@ def sssp(aiida_profile, generate_upf_data):
                 'cutoff_rho': 240.0,
             }
 
-        label = 'SSSP/1.2/PBEsol/efficiency'
+        label = 'SSSP/1.3/PBEsol/efficiency'
         family = SsspFamily.create_from_folder(dirpath, label)
 
     family.set_cutoffs(cutoffs, stringency, unit='Ry')

--- a/tests/workflows/protocols/test_hubbard/test_default.yml
+++ b/tests/workflows/protocols/test_hubbard/test_default.yml
@@ -26,6 +26,7 @@ relax:
   base:
     kpoints_distance: 0.15
     kpoints_force_parity: false
+    max_iterations: 5
     pw:
       code: test.quantumespresso.pw@localhost
       metadata:
@@ -33,6 +34,7 @@ relax:
           max_wallclock_seconds: 43200
           resources:
             num_machines: 1
+            num_mpiprocs_per_machine: 1
           withmpi: true
       parameters:
         CELL:
@@ -65,6 +67,7 @@ relax:
 scf:
   kpoints_distance: 0.4
   kpoints_force_parity: false
+  max_iterations: 5
   pw:
     code: test.quantumespresso.pw@localhost
     metadata:
@@ -72,6 +75,7 @@ scf:
         max_wallclock_seconds: 43200
         resources:
           num_machines: 1
+          num_mpiprocs_per_machine: 1
         withmpi: true
     parameters:
       CONTROL:


### PR DESCRIPTION
As aiida-quantumespresso v4.5, the default version for SSSP in protocol has been bumped to SSSP/1.3/PBEsol/efficiency. Moreover, additional inputs now appear by default in testing, such as the missing `max_iterations`. We follow by simply updating the tests accordingly.