### PR TITLE
DevOps: update python dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
 
             strategy:
                 matrix:
-                    python-version: ['3.9', '3.11']
+                    python-version: ['3.9', '3.12']
 
             defaults:
                 run:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,12 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
 ]
 keywords = ['aiida', 'workflows']
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
-    'aiida-core>=2.2.2,<=2.5',
+    'aiida-core>=2.3,<=2.5',
     'aiida-quantumespresso>=4.8',
 ]
 


### PR DESCRIPTION
Update dependencies for python to include also v3.12.
Constrain aiida-core version also to >=2.3, as in
aiida-quantumespresso. Update CI to run with python v3.12.