### PR TITLE
DevOps: update github actions version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,7 @@ jobs:
 
         steps:
         -   name: Checkout source
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
 
         -   name: Set up Python 3.9
             uses: actions/setup-python@v2
@@ -30,10 +30,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        -   uses: actions/checkout@v2
+        -   uses: actions/checkout@v4
 
         -   name: Cache Python dependencies
-            uses: actions/cache@v1
+            uses: actions/cache@v4
             with:
                 path: ~/.cache/pip
                 key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
@@ -69,10 +69,10 @@ jobs:
                 -   5672:5672
 
         steps:
-        -   uses: actions/checkout@v2
+        -   uses: actions/checkout@v4
 
         -   name: Cache Python dependencies
-            uses: actions/cache@v1
+            uses: actions/cache@v4
             with:
                 path: ~/.cache/pip
                 key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
@@ -98,7 +98,7 @@ jobs:
 
         steps:
         -   name: Checkout source
-            uses: actions/checkout@v2
+            uses: actions/checkout@v4
 
         -   name: Set up Python 3.9
             uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
         -   name: Cache python dependencies
             id: cache-pip
-            uses: actions/cache@v1
+            uses: actions/cache@v4
             with:
                 path: ~/.cache/pip
                 key: pip-pre-commit-${{ hashFiles('**/setup.json') }}
@@ -49,11 +49,11 @@ jobs:
                 -   5672:5672
 
         steps:
-        -   uses: actions/checkout@v2
+        -   uses: actions/checkout@v4
 
         -   name: Cache python dependencies
             id: cache-pip
-            uses: actions/cache@v1
+            uses: actions/cache@v4
             with:
                 path: ~/.cache/pip
                 key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
@@ -114,7 +114,7 @@ jobs:
             -   uses: actions/checkout@v4
 
             -   name: Cache Python dependencies
-                uses: actions/cache@v1
+                uses: actions/cache@v4
                 with:
                     path: ~/.cache/pip
                     key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}


### PR DESCRIPTION
Some github actions version have been deprecated.
We update to the last version available.