### PR TITLE
`HpCalculation`: fix error message for exit code 495

### DIFF
--- a/src/aiida_hubbard/calculations/hp.py
+++ b/src/aiida_hubbard/calculations/hp.py
@@ -197,7 +197,7 @@ class HpCalculation(CalcJob):
         spec.exit_code(490, 'ERROR_MISSING_CHI_MATRICES',
             message='The code failed to reconstruct the full chi matrix as some chi matrices were missing')
         spec.exit_code(495, 'ERROR_INCOMPATIBLE_FFT_GRID',
-            message='The code failed due to incompatibility between the FFT grid and the parallelization options.')
+            message='The code failed due an incompatible FFT grid.')
         # yapf: enable
 
     @classproperty


### PR DESCRIPTION
Fixes #92

The exit code 495 message speaks about problems with the "parallelization options".
This is not the case, as the problem is only due an incompatible FFT grid with the
symmetries found. This can happen at the perturbative level when a structure is close to
an other space group symmetry, leading to noise in their detection and usage within the
linear-response package of QE. This can in principle be fixed by using the corresponding
ibrav, by swithing off symmetries (not recommended), or by relaxing better the structure.
Automated handling of such case can be implemented in the future at higher level in the
SelfConsistentHubbardWorkChain.