### PR TITLE
Deps: bump aiida-core version to be 2.7.0 or higher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,13 +113,13 @@ jobs:
             steps:
             -   uses: actions/checkout@v4
 
-            -   name: Cache Python dependencies
-                uses: actions/cache@v4
-                with:
-                    path: ~/.cache/pip
-                    key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-                    restore-keys:
-                        pip-${{ matrix.python-version }}-tests
+            # -   name: Cache Python dependencies
+            #     uses: actions/cache@v4
+            #     with:
+            #         path: ~/.cache/pip
+            #         key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
+            #         restore-keys:
+            #             pip-${{ matrix.python-version }}-tests
 
             -   name: Setup Conda
                 uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,14 +113,6 @@ jobs:
             steps:
             -   uses: actions/checkout@v4
 
-            # -   name: Cache Python dependencies
-            #     uses: actions/cache@v4
-            #     with:
-            #         path: ~/.cache/pip
-            #         key: pip-${{ matrix.python-version }}-tests-${{ hashFiles('**/setup.json') }}
-            #         restore-keys:
-            #             pip-${{ matrix.python-version }}-tests
-
             -   name: Setup Conda
                 uses: conda-incubator/setup-miniconda@v3
                 with:
@@ -129,7 +121,7 @@ jobs:
                     auto-activate-base: true
 
             -   name: Set up Quantum ESPRESSO
-                run: conda install -y qe pip
+                run: conda install -y qe pip aiida-core
 
             -   name: Install Python dependencies
                 run: pip install -e .[tests]

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,10 @@
 channels:
   - conda-forge
 dependencies:
-  - qe>=7.4
+  - qe~=7.4
   - python=3.9
   - pip
-  - aiida-core~=2.5.0
+  - aiida-core~=2.7
   - xmltodict
   - jupyterlab=3
   - jupyterlab-myst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.9'
 dependencies = [
-    'aiida-core>=2.3,<2.6',
+    'aiida-core>=2.3,!=2.6.*',
     'aiida-quantumespresso>=4.10',
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.9'
 dependencies = [
-    'aiida-core>=2.3,!=2.6.*',
-    'aiida-quantumespresso>=4.10',
+    'aiida-core>=2.3,!=2.6.*,<3.0',
+    'aiida-quantumespresso>=4.10,<5.0',
 ]
 
 [project.urls]


### PR DESCRIPTION
The problematic handling of the folders for the correct
functioning of the HpCalculation is restored in the
new aiida-core version 2.7.0.