### PR TITLE
⬆️ Deps: support aiida-quantumespresso v5.0

### DIFF
--- a/docs/source/3_self_consistent.ipynb
+++ b/docs/source/3_self_consistent.ipynb
@@ -17,53 +17,21 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:00:13.554413Z",
+     "iopub.status.busy": "2026-08-19T15:00:13.554312Z",
+     "iopub.status.idle": "2026-08-19T15:00:16.314264Z",
+     "shell.execute_reply": "2026-08-19T15:00:16.313910Z"
+    },
     "tags": [
      "hide-cell"
     ]
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:46: AiidaDeprecationWarning: The `Code` class is deprecated. To create an instance, use the `aiida.orm.nodes.data.code.installed.InstalledCode` or `aiida.orm.nodes.data.code.portable.PortableCode` for a \"remote\" or \"local\" code, respectively. If you are using this class to compare type, e.g. in `isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:58: AiidaDeprecationWarning: The `Code` plugin is deprecated, use the `InstalledCode` (`core.code.remote`) instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:493: AiidaDeprecationWarning: `Code.set_remote_computer_exec` method is deprecated, use `InstalledCode`. (this will be removed in v3)\n",
-      "  warn_deprecation('`Code.set_remote_computer_exec` method is deprecated, use `InstalledCode`.', version=3)\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:406: AiidaDeprecationWarning: `Code.set_input_plugin_name` method is deprecated, use the `default_calc_job_plugin` property instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:386: AiidaDeprecationWarning: `Code.set_prepend_text` method is deprecated, use the `prepend_text` property instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:46: AiidaDeprecationWarning: The `Code` class is deprecated. To create an instance, use the `aiida.orm.nodes.data.code.installed.InstalledCode` or `aiida.orm.nodes.data.code.portable.PortableCode` for a \"remote\" or \"local\" code, respectively. If you are using this class to compare type, e.g. in `isinstance`, use `aiida.orm.nodes.data.code.abstract.AbstractCode`. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:58: AiidaDeprecationWarning: The `Code` plugin is deprecated, use the `InstalledCode` (`core.code.remote`) instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:493: AiidaDeprecationWarning: `Code.set_remote_computer_exec` method is deprecated, use `InstalledCode`. (this will be removed in v3)\n",
-      "  warn_deprecation('`Code.set_remote_computer_exec` method is deprecated, use `InstalledCode`.', version=3)\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:406: AiidaDeprecationWarning: `Code.set_input_plugin_name` method is deprecated, use the `default_calc_job_plugin` property instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:386: AiidaDeprecationWarning: `Code.set_prepend_text` method is deprecated, use the `prepend_text` property instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "<HubbardStructureData: uuid: 92ee7a92-955a-418f-9bbf-421c5fa9026a (pk: 106)>"
+       "<HubbardStructureData: uuid: fe746b58-11be-4f89-8f6a-cad9ea32e2c7 (pk: 106)>"
       ]
      },
      "execution_count": 1,
@@ -149,6 +117,12 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:00:16.315822Z",
+     "iopub.status.busy": "2026-08-19T15:00:16.315747Z",
+     "iopub.status.idle": "2026-08-19T15:04:34.429428Z",
+     "shell.execute_reply": "2026-08-19T15:04:34.429099Z"
+    },
     "tags": [
      "hide-output"
     ]
@@ -158,156 +132,434 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "02/18/2025 09:47:37 AM <48624> aiida.engine.processes.functions: [WARNING] function `structure_relabel_kinds` has invalid type hints: unsupported operand type(s) for |: 'type' and 'NoneType'\n",
-      "02/18/2025 09:47:38 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|setup]: system is treated to be non-magnetic because `nspin == 1` in `scf.pw.parameters` input.\n",
-      "02/18/2025 09:47:39 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|run_relax]: launching PwRelaxWorkChain<132> iteration #1\n",
-      "02/18/2025 09:47:39 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [132|PwRelaxWorkChain|run_relax]: launching PwBaseWorkChain<135>\n",
-      "02/18/2025 09:47:39 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [135|PwBaseWorkChain|run_process]: launching PwCalculation<140> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:48:57 AM <48624> aiida.parser.PwParser: [ERROR] Then ionic minimization cycle converged but the thresholds are exceeded in the final SCF.\n",
-      "02/18/2025 09:48:57 AM <48624> aiida.orm.nodes.process.calculation.calcjob.CalcJobNode: [WARNING] output parser returned exit code<501>: Then ionic minimization cycle converged but the thresholds are exceeded in the final SCF.\n",
-      "02/18/2025 09:48:58 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [135|PwBaseWorkChain|report_error_handled]: PwCalculation<140> failed with exit status 501: Then ionic minimization cycle converged but the thresholds are exceeded in the final SCF.\n",
-      "02/18/2025 09:48:58 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [135|PwBaseWorkChain|report_error_handled]: Action taken: ionic convergence thresholds met except in final scf: consider structure relaxed.\n",
-      "02/18/2025 09:48:58 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [135|PwBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:48:58 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [135|PwBaseWorkChain|inspect_process]: PwCalculation<140> failed but a handler detected an unrecoverable problem, aborting\n",
-      "02/18/2025 09:48:58 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [135|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:48:59 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [132|PwRelaxWorkChain|inspect_relax]: after iteration 1 cell volume of relaxed structure is 39.73526676170027\n",
-      "02/18/2025 09:49:00 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [132|PwRelaxWorkChain|run_relax]: launching PwBaseWorkChain<149>\n",
-      "02/18/2025 09:49:00 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [149|PwBaseWorkChain|run_process]: launching PwCalculation<154> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:49:16 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [149|PwBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:49:16 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [149|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:49:17 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [132|PwRelaxWorkChain|inspect_relax]: after iteration 2 cell volume of relaxed structure is 39.70324991346442\n",
-      "02/18/2025 09:49:17 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [132|PwRelaxWorkChain|inspect_relax]: relative cell volume difference 0.0008057539522223223 smaller than threshold 0.05\n",
-      "02/18/2025 09:49:17 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [132|PwRelaxWorkChain|results]: workchain completed after 2 iterations\n",
-      "02/18/2025 09:49:17 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [132|PwRelaxWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:49:18 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|run_scf_smearing]: launching PwBaseWorkChain<163> with smeared occupations\n",
-      "02/18/2025 09:49:18 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [163|PwBaseWorkChain|run_process]: launching PwCalculation<168> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:49:25 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [163|PwBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:49:25 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [163|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:49:26 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|recon_scf]: after relaxation, system is determined to be an insulator\n",
-      "02/18/2025 09:49:26 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|run_scf_fixed]: launching PwBaseWorkChain<176> with fixed occupations\n",
-      "02/18/2025 09:49:27 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [176|PwBaseWorkChain|run_process]: launching PwCalculation<181> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:49:35 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [176|PwBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:49:35 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [176|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:49:37 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|run_hp]: launching HpWorkChain<189> iteration #1\n",
-      "02/18/2025 09:49:38 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [189|HpWorkChain|run_base_workchain]: running in serial, launching HpBaseWorkChain<195>\n",
-      "02/18/2025 09:49:38 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [195|HpBaseWorkChain|run_process]: launching HpCalculation<198> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:49:42 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [195|HpBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:49:42 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [195|HpBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:49:42 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [195|HpBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:49:43 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [189|HpWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:49:44 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|check_convergence]: Hubbard onsites parameters are not converged. Max difference is 8.05849999.\n",
-      "02/18/2025 09:49:44 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|run_relax]: launching PwRelaxWorkChain<207> iteration #2\n",
-      "02/18/2025 09:49:44 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [207|PwRelaxWorkChain|run_relax]: launching PwBaseWorkChain<210>\n",
-      "02/18/2025 09:49:45 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [210|PwBaseWorkChain|run_process]: launching PwCalculation<215> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:50:22 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [210|PwBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:50:23 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [210|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:50:23 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [207|PwRelaxWorkChain|inspect_relax]: after iteration 1 cell volume of relaxed structure is 41.098653115003856\n",
-      "02/18/2025 09:50:24 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [207|PwRelaxWorkChain|run_relax]: launching PwBaseWorkChain<224>\n",
-      "02/18/2025 09:50:24 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [224|PwBaseWorkChain|run_process]: launching PwCalculation<229> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:50:32 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [224|PwBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:50:32 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [224|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:50:32 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [207|PwRelaxWorkChain|inspect_relax]: after iteration 2 cell volume of relaxed structure is 41.09865257522646\n",
-      "02/18/2025 09:50:32 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [207|PwRelaxWorkChain|inspect_relax]: relative cell volume difference 1.3133700381935236e-08 smaller than threshold 0.05\n",
-      "02/18/2025 09:50:32 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [207|PwRelaxWorkChain|results]: workchain completed after 2 iterations\n",
-      "02/18/2025 09:50:32 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [207|PwRelaxWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:50:33 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|run_scf_smearing]: launching PwBaseWorkChain<238> with smeared occupations\n",
-      "02/18/2025 09:50:33 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [238|PwBaseWorkChain|run_process]: launching PwCalculation<243> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:50:37 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [238|PwBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:50:37 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [238|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:50:37 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|recon_scf]: after relaxation, system is determined to be an insulator\n",
-      "02/18/2025 09:50:38 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|run_scf_fixed]: launching PwBaseWorkChain<251> with fixed occupations\n",
-      "02/18/2025 09:50:38 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [251|PwBaseWorkChain|run_process]: launching PwCalculation<256> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:50:41 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [251|PwBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:50:41 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [251|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:50:42 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|run_hp]: launching HpWorkChain<264> iteration #2\n",
-      "02/18/2025 09:50:43 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [264|HpWorkChain|run_base_workchain]: running in serial, launching HpBaseWorkChain<270>\n",
-      "02/18/2025 09:50:43 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [270|HpBaseWorkChain|run_process]: launching HpCalculation<273> iteration #1\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:523: AiidaDeprecationWarning: `Code.get_remote_computer` method is deprecated, use the `computer` attribute instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:565: AiidaDeprecationWarning: `Code.is_local` method is deprecated, use a `PortableCode` instance and check the type. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "/opt/conda/lib/python3.9/site-packages/aiida/orm/nodes/data/code/legacy.py:513: AiidaDeprecationWarning: `Code.get_remote_exec_path` method is deprecated, use `InstalledCode.filepath_executable` instead. (this will be removed in v3)\n",
-      "  warn_deprecation(\n",
-      "02/18/2025 09:50:46 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [270|HpBaseWorkChain|results]: work chain completed after 1 iterations\n",
-      "02/18/2025 09:50:46 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [270|HpBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:50:46 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [270|HpBaseWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:50:47 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [264|HpWorkChain|on_terminated]: remote folders will not be cleaned\n",
-      "02/18/2025 09:50:47 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|check_convergence]: Hubbard parameters are converged. Stopping the cycle.\n",
-      "02/18/2025 09:50:48 AM <48624> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [130|SelfConsistentHubbardWorkChain|run_results]: Hubbard parameters self-consistently converged in 2 iterations\n"
+      "08/19/2026 11:00:16 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|setup]: system is treated to be non-magnetic because `nspin == 1` in `scf.pw.parameters` input.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:00:16 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|run_relax]: launching PwRelaxWorkChain<136> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:00:16 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [136|PwRelaxWorkChain|run_init_relax]: launching PwBaseWorkChain<138> for initial relaxation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:00:17 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [138|PwBaseWorkChain|run_process]: launching PwCalculation<143> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:01:04 AM <52115> aiida.parser.PwParser: [ERROR] The ionic minimization cycle converged but the thresholds are exceeded in the final SCF.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:01:04 AM <52115> aiida.orm.nodes.process.calculation.calcjob.CalcJobNode: [WARNING] output parser returned exit code<501>: The ionic minimization cycle converged but the thresholds are exceeded in the final SCF.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:01:04 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [138|PwBaseWorkChain|report_error_handled]: PwCalculation<143> failed with exit status 501: The ionic minimization cycle converged but the thresholds are exceeded in the final SCF.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:01:04 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [138|PwBaseWorkChain|report_error_handled]: Action taken: consider structure final, but report exit code.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:01:04 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [138|PwBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:01:05 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [138|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:01:06 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [136|PwRelaxWorkChain|run_relax]: launching PwBaseWorkChain<152>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:01:06 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [152|PwBaseWorkChain|run_process]: launching PwCalculation<157> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:02 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [152|PwBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:02 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [152|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:03 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [136|PwRelaxWorkChain|should_run_relax]: Work chain completed after 1 iterations.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:03 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [136|PwRelaxWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:03 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|run_scf_smearing]: launching PwBaseWorkChain<166> with smeared occupations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:03 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [166|PwBaseWorkChain|run_process]: launching PwCalculation<171> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:10 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [166|PwBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:10 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [166|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:11 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|recon_scf]: after relaxation, system is determined to be an insulator\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:11 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|run_scf_fixed]: launching PwBaseWorkChain<179> with fixed occupations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:11 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [179|PwBaseWorkChain|run_process]: launching PwCalculation<184> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:17 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [179|PwBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:17 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [179|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:18 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|run_hp]: launching HpWorkChain<192> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:18 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [192|HpWorkChain|run_base_workchain]: running in serial, launching HpBaseWorkChain<198>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:19 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [198|HpBaseWorkChain|run_process]: launching HpCalculation<201> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:25 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [198|HpBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:25 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [198|HpBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:25 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [198|HpBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:26 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [192|HpWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:27 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|check_convergence]: Hubbard onsites parameters are not converged. Max difference is 8.05399999.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:27 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|run_relax]: launching PwRelaxWorkChain<211> iteration #2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:27 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [211|PwRelaxWorkChain|run_init_relax]: launching PwBaseWorkChain<213> for initial relaxation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:02:27 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [213|PwBaseWorkChain|run_process]: launching PwCalculation<218> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:03:22 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [213|PwBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:03:23 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [213|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:03:23 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [211|PwRelaxWorkChain|run_relax]: launching PwBaseWorkChain<227>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:03:23 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [227|PwBaseWorkChain|run_process]: launching PwCalculation<232> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:10 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [227|PwBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:10 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [227|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:11 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [211|PwRelaxWorkChain|should_run_relax]: Work chain completed after 1 iterations.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:11 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [211|PwRelaxWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:12 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|run_scf_smearing]: launching PwBaseWorkChain<241> with smeared occupations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:12 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [241|PwBaseWorkChain|run_process]: launching PwCalculation<246> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:19 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [241|PwBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:19 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [241|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:19 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|recon_scf]: after relaxation, system is determined to be an insulator\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:20 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|run_scf_fixed]: launching PwBaseWorkChain<254> with fixed occupations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:20 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [254|PwBaseWorkChain|run_process]: launching PwCalculation<259> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:24 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [254|PwBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:24 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [254|PwBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:25 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|run_hp]: launching HpWorkChain<267> iteration #2\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:25 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [267|HpWorkChain|run_base_workchain]: running in serial, launching HpBaseWorkChain<273>\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:25 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [273|HpBaseWorkChain|run_process]: launching HpCalculation<276> iteration #1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:32 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [273|HpBaseWorkChain|results]: work chain completed after 1 iterations\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:32 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [273|HpBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:32 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [273|HpBaseWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:33 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [267|HpWorkChain|on_terminated]: remote folders will not be cleaned\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:34 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|check_convergence]: Hubbard parameters are converged. Stopping the cycle.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "08/19/2026 11:04:34 AM <52115> aiida.orm.nodes.process.workflow.workchain.WorkChainNode: [REPORT] [133|SelfConsistentHubbardWorkChain|run_results]: Hubbard parameters self-consistently converged in 2 iterations\n"
      ]
     }
    ],
@@ -325,7 +577,18 @@
     "        \"tolerance_onsite\": 0.5,\n",
     "        \"tolerance_intersite\": 0.1,\n",
     "        \"relax\":{\n",
-    "            \"base\":{\n",
+    "            \"base_init_relax\":{\n",
+    "                \"kpoints_distance\":100.0,\n",
+    "                \"pw\":{\n",
+    "                    \"parameters\":{\n",
+    "                        \"SYSTEM\":{\n",
+    "                            \"ecutwfc\": 60.0, # to speed up the tutorial\n",
+    "                            \"ecutrho\": 60.0 * 8,\n",
+    "                        },\n",
+    "                    },\n",
+    "                },\n",
+    "            },\n",
+    "            \"base_relax\":{\n",
     "                \"kpoints_distance\":100.0,\n",
     "                \"pw\":{\n",
     "                    \"parameters\":{\n",
@@ -365,47 +628,54 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:04:34.431115Z",
+     "iopub.status.busy": "2026-08-19T15:04:34.431061Z",
+     "iopub.status.idle": "2026-08-19T15:04:34.519437Z",
+     "shell.execute_reply": "2026-08-19T15:04:34.519049Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[22mSelfConsistentHubbardWorkChain<130> Finished [0] [2:run_results]\n",
-      "    ├── PwRelaxWorkChain<132> Finished [0] [3:results]\n",
-      "    │   ├── PwBaseWorkChain<135> Finished [501] [2:while_(should_run_process)(2:inspect_process)]\n",
-      "    │   │   ├── create_kpoints_from_distance<136> Finished [0]\n",
-      "    │   │   └── PwCalculation<140> Finished [501]\n",
-      "    │   └── PwBaseWorkChain<149> Finished [0] [3:results]\n",
-      "    │       ├── create_kpoints_from_distance<150> Finished [0]\n",
-      "    │       └── PwCalculation<154> Finished [0]\n",
-      "    ├── PwBaseWorkChain<163> Finished [0] [3:results]\n",
-      "    │   ├── create_kpoints_from_distance<164> Finished [0]\n",
-      "    │   └── PwCalculation<168> Finished [0]\n",
-      "    ├── PwBaseWorkChain<176> Finished [0] [3:results]\n",
-      "    │   ├── create_kpoints_from_distance<177> Finished [0]\n",
-      "    │   └── PwCalculation<181> Finished [0]\n",
-      "    ├── HpWorkChain<189> Finished [0] [3:results]\n",
-      "    │   ├── create_kpoints_from_distance<191> Finished [0]\n",
-      "    │   └── HpBaseWorkChain<195> Finished [0] [3:results]\n",
-      "    │       └── HpCalculation<198> Finished [0]\n",
-      "    ├── PwRelaxWorkChain<207> Finished [0] [3:results]\n",
-      "    │   ├── PwBaseWorkChain<210> Finished [0] [3:results]\n",
-      "    │   │   ├── create_kpoints_from_distance<211> Finished [0]\n",
-      "    │   │   └── PwCalculation<215> Finished [0]\n",
-      "    │   └── PwBaseWorkChain<224> Finished [0] [3:results]\n",
-      "    │       ├── create_kpoints_from_distance<225> Finished [0]\n",
-      "    │       └── PwCalculation<229> Finished [0]\n",
-      "    ├── PwBaseWorkChain<238> Finished [0] [3:results]\n",
-      "    │   ├── create_kpoints_from_distance<239> Finished [0]\n",
-      "    │   └── PwCalculation<243> Finished [0]\n",
-      "    ├── PwBaseWorkChain<251> Finished [0] [3:results]\n",
-      "    │   ├── create_kpoints_from_distance<252> Finished [0]\n",
-      "    │   └── PwCalculation<256> Finished [0]\n",
-      "    └── HpWorkChain<264> Finished [0] [3:results]\n",
-      "        ├── create_kpoints_from_distance<266> Finished [0]\n",
-      "        └── HpBaseWorkChain<270> Finished [0] [3:results]\n",
-      "            └── HpCalculation<273> Finished [0]\u001b[0m\n"
+      "\u001b[22mSelfConsistentHubbardWorkChain<133> Finished [0] [2:run_results]\n",
+      "    ├── PwRelaxWorkChain<136> Finished [0] [3:results]\n",
+      "    │   ├── PwBaseWorkChain<138> Finished [501] [2:while_(should_run_process)(2:inspect_process)]\n",
+      "    │   │   ├── create_kpoints_from_distance<139> Finished [0]\n",
+      "    │   │   └── PwCalculation<143> Finished [501]\n",
+      "    │   └── PwBaseWorkChain<152> Finished [0] [3:results]\n",
+      "    │       ├── create_kpoints_from_distance<153> Finished [0]\n",
+      "    │       └── PwCalculation<157> Finished [0]\n",
+      "    ├── PwBaseWorkChain<166> Finished [0] [3:results]\n",
+      "    │   ├── create_kpoints_from_distance<167> Finished [0]\n",
+      "    │   └── PwCalculation<171> Finished [0]\n",
+      "    ├── PwBaseWorkChain<179> Finished [0] [3:results]\n",
+      "    │   ├── create_kpoints_from_distance<180> Finished [0]\n",
+      "    │   └── PwCalculation<184> Finished [0]\n",
+      "    ├── HpWorkChain<192> Finished [0] [3:results]\n",
+      "    │   ├── create_kpoints_from_distance<194> Finished [0]\n",
+      "    │   └── HpBaseWorkChain<198> Finished [0] [3:results]\n",
+      "    │       └── HpCalculation<201> Finished [0]\n",
+      "    ├── PwRelaxWorkChain<211> Finished [0] [3:results]\n",
+      "    │   ├── PwBaseWorkChain<213> Finished [0] [3:results]\n",
+      "    │   │   ├── create_kpoints_from_distance<214> Finished [0]\n",
+      "    │   │   └── PwCalculation<218> Finished [0]\n",
+      "    │   └── PwBaseWorkChain<227> Finished [0] [3:results]\n",
+      "    │       ├── create_kpoints_from_distance<228> Finished [0]\n",
+      "    │       └── PwCalculation<232> Finished [0]\n",
+      "    ├── PwBaseWorkChain<241> Finished [0] [3:results]\n",
+      "    │   ├── create_kpoints_from_distance<242> Finished [0]\n",
+      "    │   └── PwCalculation<246> Finished [0]\n",
+      "    ├── PwBaseWorkChain<254> Finished [0] [3:results]\n",
+      "    │   ├── create_kpoints_from_distance<255> Finished [0]\n",
+      "    │   └── PwCalculation<259> Finished [0]\n",
+      "    └── HpWorkChain<267> Finished [0] [3:results]\n",
+      "        ├── create_kpoints_from_distance<269> Finished [0]\n",
+      "        └── HpBaseWorkChain<273> Finished [0] [3:results]\n",
+      "            └── HpCalculation<276> Finished [0]\u001b[0m\n"
      ]
     }
    ],
@@ -424,7 +694,14 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-19T15:04:34.520398Z",
+     "iopub.status.busy": "2026-08-19T15:04:34.520348Z",
+     "iopub.status.idle": "2026-08-19T15:04:34.522779Z",
+     "shell.execute_reply": "2026-08-19T15:04:34.522432Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -477,9 +754,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.11"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "d4d1e4263499bec80672ea0156c357c1ee493ec2b1c70f0acce89fc37c4a6abe"

--- a/examples/example_sc_hubbard.py
+++ b/examples/example_sc_hubbard.py
@@ -42,7 +42,10 @@ def test_self_consistent_hubbard():
         protocol='fast',
         overrides={  # this can be more conveniently moved on file as .yaml file
             # 'relax':{
-            #     'base':{
+            #     'base_init_relax':{
+            #         'kpoints_distance': 100.0, # so high that it gives 1x1x1
+            #     },
+            #     'base_relax':{
             #         'kpoints_distance': 100.0, # so high that it gives 1x1x1
             #     },
             # },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ classifiers = [
 keywords = ['aiida', 'workflows']
 requires-python = '>=3.10'
 dependencies = [
-    'aiida-core~=2.3,!=2.6',
-    'aiida-quantumespresso~=4.15',
+    'aiida-core~=2.8',
+    'aiida-quantumespresso~=5.0',
 ]
 
 [project.urls]

--- a/src/aiida_hubbard/calculations/hp.py
+++ b/src/aiida_hubbard/calculations/hp.py
@@ -8,13 +8,18 @@ from aiida import orm
 from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.common.utils import classproperty
 from aiida.plugins import CalculationFactory, DataFactory
-from aiida_quantumespresso.calculations import CalcJob, _lowercase_dict, _uppercase_dict
+from aiida_quantumespresso.calculations import CalcJob, _case_transform_dict, _uppercase_dict
 from aiida_quantumespresso.utils.convert import convert_input_to_namelist_entry
 
 from aiida_hubbard.utils.general import is_perturb_only_atom
 
 PwCalculation = CalculationFactory('quantumespresso.pw')
 HubbardStructureData = DataFactory('quantumespresso.hubbard_structure')
+
+
+def _lowercase_dict(dictionary, dict_name):
+    """Return a copy of the dictionary with all keys lowercase, raising if that induces key clashes."""
+    return _case_transform_dict(dictionary, dict_name, '_lowercase_dict', str.lower)
 
 
 def validate_parent_scf(parent_scf, _):

--- a/src/aiida_hubbard/cli/__init__.py
+++ b/src/aiida_hubbard/cli/__init__.py
@@ -6,8 +6,8 @@ import click
 
 
 @click.group('aiida-hubbard', cls=VerdiCommandGroup, context_settings={'help_option_names': ['-h', '--help']})
-@options.PROFILE(type=types.ProfileParamType(load_profile=True))
-def cmd_root(profile):
+@options.PROFILE(type=types.ProfileParamType(load_profile=True), expose_value=False)
+def cmd_root():
     """CLI for the `aiida-hubbard` plugin."""
 
 

--- a/src/aiida_hubbard/cli/calculations/hp.py
+++ b/src/aiida_hubbard/cli/calculations/hp.py
@@ -1,48 +1,62 @@
 """Command line scripts to launch a `HpCalculation` for testing and demonstration purposes."""
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
-from aiida_quantumespresso.cli.utils import launch
-from aiida_quantumespresso.cli.utils import options as options_qe
 import click
+from click.core import ParameterSource
 
+from ..utils import launch, options
 from . import cmd_launch
 
 
 @cmd_launch.command('hp')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.hp'))
-@options_qe.KPOINTS_MESH(default=[1, 1, 1])
-@options_qe.PARENT_FOLDER(type=types.DataParamType(sub_classes=('aiida.data:core.remote',)))
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
-@options.DRY_RUN()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.hp'))
+@options.PARENT_FOLDER()
+@options.HUBBARD_STRUCTURE()
+@options.QPOINTS_MESH(default=(1, 1, 1), show_default=True)
+@options.MAX_NUM_MACHINES(default=1, show_default=True)
+@options.MAX_WALLCLOCK_SECONDS(default=1800, show_default=True)
+@options.WITH_MPI(default=False, show_default=True)
+@options.DAEMON()
+@options_core.DRY_RUN()
+@click.pass_context
 @decorators.with_dbenv()
 def launch_calculation(
-    code, kpoints_mesh, parent_folder, max_num_machines, max_wallclock_seconds, with_mpi, daemon, dry_run
+    ctx,
+    code,
+    parent_folder,
+    hubbard_structure,
+    qpoints_mesh,
+    max_num_machines,
+    max_wallclock_seconds,
+    with_mpi,
+    daemon,
+    dry_run,
 ):
-    """Run a `HpCalculation`."""
-    from aiida.orm import Dict
+    """Run an `HpCalculation`."""
+    from aiida import orm
     from aiida.plugins import CalculationFactory
     from aiida_quantumespresso.utils.resources import get_default_options
 
-    parameters = {'INPUTHP': {}}
-
     inputs = {
         'code': code,
-        'qpoints': kpoints_mesh,
-        'parameters': Dict(parameters),
+        'qpoints': qpoints_mesh,
+        'parameters': orm.Dict({'INPUTHP': {}}),
         'parent_scf': parent_folder,
         'metadata': {
             'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi),
         },
     }
 
+    if hubbard_structure:
+        inputs['hubbard_structure'] = hubbard_structure
+
     if dry_run:
-        if daemon:
+        if daemon and ctx.get_parameter_source('daemon') is not ParameterSource.DEFAULT:
             raise click.BadParameter('cannot send to the daemon if in dry_run mode', param_hint='--daemon')
-        inputs.setdefault('metadata', {})['store_provenance'] = False
+        daemon = False
+        inputs['metadata']['store_provenance'] = False
         inputs['metadata']['dry_run'] = True
 
     launch.launch_process(CalculationFactory('quantumespresso.hp'), daemon, **inputs)

--- a/src/aiida_hubbard/cli/utils/__init__.py
+++ b/src/aiida_hubbard/cli/utils/__init__.py
@@ -1,0 +1,52 @@
+"""Utilities for the command line interface."""
+
+import click
+
+
+def validate_parallelization(parallelize_atoms, parallelize_qpoints):
+    """Validate the parallelization options of the ``HpWorkChain``.
+
+    Parallelization over the perturbations (q-points) is only possible if the calculation is also parallelized over
+    the Hubbard atoms. Explicitly requesting the former while disabling the latter is therefore an error, whereas
+    disabling the latter without specifying the former simply implies that the former is disabled as well.
+
+    :param parallelize_atoms: whether to parallelize over the Hubbard atoms, or ``None`` if not specified.
+    :param parallelize_qpoints: whether to parallelize over the q-points, or ``None`` if not specified.
+    :return: tuple of the validated ``parallelize_atoms`` and ``parallelize_qpoints`` values.
+    :raises click.BadParameter: if q-point parallelization is requested without atom parallelization.
+    """
+    if parallelize_atoms is False:
+        if parallelize_qpoints:
+            raise click.BadParameter(
+                'q-point parallelization is only possible when parallelizing over the Hubbard atoms',
+                param_hint='--parallelize-qpoints',
+            )
+        parallelize_qpoints = False
+
+    return parallelize_atoms, parallelize_qpoints
+
+
+def get_options(max_num_machines=None, max_wallclock_seconds=None, with_mpi=None):
+    """Return a ``metadata.options`` dictionary containing only the options that were explicitly specified.
+
+    The returned dictionary is intended to be passed to the ``options`` keyword of a ``get_builder_from_protocol``
+    method, where it is recursively merged with the options defined by the protocol. Returning ``None`` when nothing
+    was specified therefore guarantees that the protocol defaults are left untouched.
+
+    :param max_num_machines: the maximum number of machines (nodes) to use for the calculations.
+    :param max_wallclock_seconds: the maximum wallclock time in seconds to set for the calculations.
+    :param with_mpi: whether to run the calculations with MPI enabled.
+    :return: dictionary of ``metadata.options`` or ``None`` if no option was specified.
+    """
+    options = {}
+
+    if max_num_machines is not None:
+        options['resources'] = {'num_machines': max_num_machines}
+
+    if max_wallclock_seconds is not None:
+        options['max_wallclock_seconds'] = max_wallclock_seconds
+
+    if with_mpi is not None:
+        options['withmpi'] = with_mpi
+
+    return options or None

--- a/src/aiida_hubbard/cli/utils/defaults.py
+++ b/src/aiida_hubbard/cli/utils/defaults.py
@@ -1,0 +1,41 @@
+"""Module with utilities for the CLI to generate default values."""
+
+
+def get_hubbard_structure():
+    """Return a ``HubbardStructureData`` representing bulk LiCoO2 with an initialized on-site Hubbard U on cobalt.
+
+    The database will first be queried for the existence of such a structure. If this is not the case, one is created
+    and stored. This function should be used as a default for CLI options that require a ``HubbardStructureData`` node.
+    This way new users can launch the command without having to construct or import a structure first. This is the
+    reason that we hardcode a LiCoO2 crystal to be returned: it is the prototypical example of the Quantum ESPRESSO
+    ``hp.x`` documentation. More flexibility is not required for this purpose.
+
+    :return: the UUID of a ``HubbardStructureData`` representing bulk LiCoO2
+    """
+    from aiida.orm import QueryBuilder
+    from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
+
+    # Filters that will match any LiCoO2 structure with 4 sites and 3 kinds in total
+    filters = {
+        'attributes.sites': {'of_length': 4},
+        'attributes.kinds': {'of_length': 3},
+        'attributes.kinds.0.symbols.0': 'Co',
+    }
+
+    builder = QueryBuilder().append(HubbardStructureData, filters=filters)
+    structure = builder.first(flat=True)
+
+    if not structure:
+        a, b, c, d = 1.40803, 0.81293, 4.68453, 1.62585
+        cell = [[a, -b, c], [0.0, d, c], [-a, -b, c]]
+        sites = [
+            ('Co', 'Co', (0.0, 0.0, 0.0)),
+            ('O', 'O', (0.0, 0.0, 3.6608)),
+            ('O', 'O', (0.0, 0.0, 10.392)),
+            ('Li', 'Li', (0.0, 0.0, 7.0268)),
+        ]
+        structure = HubbardStructureData(cell=cell, sites=sites)
+        structure.initialize_onsites_hubbard('Co', '3d', 5.0)
+        structure.store()
+
+    return structure.uuid

--- a/src/aiida_hubbard/cli/utils/display.py
+++ b/src/aiida_hubbard/cli/utils/display.py
@@ -1,0 +1,42 @@
+"""Module with display utilities for the CLI."""
+
+import os
+
+import click
+
+
+def echo_process_results(node):
+    """Display a formatted table of the outputs registered for the given process node.
+
+    :param node: the `ProcessNode` of a terminated process
+    """
+    from aiida.common.links import LinkType
+
+    class_name = node.process_class.__name__
+    outputs = node.base.links.get_outgoing(link_type=(LinkType.CREATE, LinkType.RETURN)).all()
+
+    if hasattr(node, 'dry_run_info'):
+        # It is a dry-run: get the information and print it
+        rel_path = os.path.relpath(node.dry_run_info['folder'])
+        click.echo(f"-> Files created in folder '{rel_path}'")
+        click.echo(f"-> Submission script filename: '{node.dry_run_info['script_filename']}'")
+        return
+
+    if node.is_finished and node.exit_message:
+        state = f'{node.process_state.value} [{node.exit_status}] `{node.exit_message}`'
+    elif node.is_finished:
+        state = f'{node.process_state.value} [{node.exit_status}]'
+    else:
+        state = node.process_state.value
+
+    click.echo(f'{class_name}<{node.pk}> terminated with state: {state}')
+
+    if not outputs:
+        click.echo(f'{class_name}<{node.pk}> registered no outputs')
+        return
+
+    click.echo(f'\n{"Output link":25s} Node pk and type')
+    click.echo(f'{"-" * 60}')
+
+    for triple in sorted(outputs, key=lambda triple: triple.link_label):
+        click.echo(f'{triple.link_label:25s} {triple.node.__class__.__name__}<{triple.node.pk}> ')

--- a/src/aiida_hubbard/cli/utils/launch.py
+++ b/src/aiida_hubbard/cli/utils/launch.py
@@ -1,0 +1,35 @@
+"""Module with launch utilities for the CLI."""
+
+import click
+
+from .display import echo_process_results
+
+
+def launch_process(process, daemon, **inputs):
+    """Launch a process with the given inputs.
+
+    If not sent to the daemon, the results will be displayed after the calculation finishes.
+
+    :param process: the process class or a ``ProcessBuilder`` instance
+    :param daemon: boolean, if True will submit to the daemon instead of running in current interpreter
+    :param inputs: inputs for the process
+    """
+    from aiida.engine import Process, ProcessBuilder, launch
+
+    if isinstance(process, ProcessBuilder):
+        process_name = process.process_class.__name__
+    elif issubclass(process, Process):
+        process_name = process.__name__
+    else:
+        raise TypeError(f'invalid type for process: {process}')
+
+    if daemon:
+        node = launch.submit(process, **inputs)
+        click.echo(f'Submitted {process_name}<{node.pk}> to the daemon')
+    else:
+        if inputs.get('metadata', {}).get('dry_run', False):
+            click.echo(f'Running a dry run for {process_name}...')
+        else:
+            click.echo(f'Running a {process_name}...')
+        _, node = launch.run_get_node(process, **inputs)
+        echo_process_results(node)

--- a/src/aiida_hubbard/cli/utils/options.py
+++ b/src/aiida_hubbard/cli/utils/options.py
@@ -1,0 +1,250 @@
+"""Pre-defined overridable options for commonly used command line interface parameters."""
+
+from aiida.cmdline.params import types
+from aiida.cmdline.params.options import OverridableOption
+from aiida.cmdline.utils import decorators
+from aiida.common import exceptions
+from aiida_quantumespresso.common.types import ElectronicType, RelaxType, SpinType
+import click
+
+from . import validate
+
+#: The protocols that are implemented by all the work chains that are exposed through this CLI.
+PROTOCOLS = ('fast', 'balanced', 'stringent')
+
+#: The default protocol of all the work chains that are exposed through this CLI.
+DEFAULT_PROTOCOL = 'balanced'
+
+
+class PseudoFamilyType(types.GroupParamType):
+    """Subclass of `GroupParamType` in order to be able to print warning with instructions."""
+
+    def __init__(self, pseudo_types=None, **kwargs):
+        """Construct a new instance."""
+        super().__init__(**kwargs)
+        self._pseudo_types = pseudo_types
+
+    @decorators.with_dbenv()
+    def convert(self, value, param, ctx):
+        """Convert the value to actual pseudo family instance."""
+        try:
+            group = super().convert(value, param, ctx)
+        except click.BadParameter:
+            try:
+                from aiida.orm import load_group
+
+                load_group(value)
+            except exceptions.NotExistent:
+                raise
+
+            raise click.BadParameter(
+                f'`{value}` is not of a supported pseudopotential family type.\nTo install a supported '
+                'pseudofamily, use the `aiida-pseudo` plugin. See the following link for detailed instructions:\n\n'
+                '    https://github.com/aiidateam/aiida-quantumespresso#pseudopotentials'
+            )
+
+        if self._pseudo_types is not None and group.pseudo_type not in self._pseudo_types:
+            pseudo_types = ', '.join(self._pseudo_types)
+            raise click.BadParameter(
+                f'family `{group.label}` contains pseudopotentials of the wrong type `{group.pseudo_type}`.\nOnly the '
+                f'following types are supported: {pseudo_types}'
+            )
+
+        return group
+
+
+class EnumParamType(click.Choice):
+    """Subclass of ``click.Choice`` that converts the value into the corresponding member of an ``enum.Enum``."""
+
+    def __init__(self, enum, exclude=(), **kwargs):
+        """Construct a new instance.
+
+        :param enum: the enumeration whose members define the valid choices.
+        :param exclude: values of the enumeration that should not be exposed as valid choices.
+        """
+        self._enum = enum
+        super().__init__([member.value for member in enum if member.value not in exclude], **kwargs)
+
+    def convert(self, value, param, ctx):
+        """Convert the value into the corresponding member of the enumeration."""
+        if isinstance(value, self._enum):
+            return value
+
+        return self._enum(super().convert(value, param, ctx))
+
+
+PW_CODE = OverridableOption(
+    '--pw',
+    'pw_code',
+    type=types.CodeParamType(entry_point='quantumespresso.pw'),
+    required=True,
+    help='The code to use for the pw.x executable.',
+)
+
+HP_CODE = OverridableOption(
+    '--hp',
+    'hp_code',
+    type=types.CodeParamType(entry_point='quantumespresso.hp'),
+    required=True,
+    help='The code to use for the hp.x executable.',
+)
+
+HUBBARD_STRUCTURE = OverridableOption(
+    '-S',
+    '--hubbard-structure',
+    type=types.DataParamType(sub_classes=('aiida.data:quantumespresso.hubbard_structure',)),
+    help='A HubbardStructureData node identified by its ID or UUID, with initialized Hubbard parameters.',
+)
+
+PSEUDO_FAMILY = OverridableOption(
+    '-F',
+    '--pseudo-family',
+    type=PseudoFamilyType(sub_classes=('aiida.groups:pseudo.family',), pseudo_types=('pseudo.upf',)),
+    required=False,
+    help='Select a pseudopotential family, identified by its label.',
+)
+
+PROTOCOL = OverridableOption(
+    '-p',
+    '--protocol',
+    type=click.Choice(PROTOCOLS),
+    default=DEFAULT_PROTOCOL,
+    show_default=True,
+    help='Select the protocol that defines the accuracy of the calculation.',
+)
+
+OVERRIDES = OverridableOption(
+    '-o',
+    '--overrides',
+    type=click.File('r'),
+    required=False,
+    help='The filename or filepath containing the overrides for the protocol, in YAML format.',
+)
+
+PARENT_FOLDER = OverridableOption(
+    '-P',
+    '--parent-folder',
+    'parent_folder',
+    type=types.DataParamType(sub_classes=('aiida.data:core.remote',)),
+    required=True,
+    help='The remote folder of the parent pw.x SCF calculation, identified by its ID or UUID.',
+)
+
+KPOINTS_MESH = OverridableOption(
+    '-k',
+    '--kpoints-mesh',
+    'kpoints_mesh',
+    nargs=3,
+    type=click.INT,
+    callback=validate.validate_kpoints_mesh,
+    help='The number of points in the k-point mesh along each basis vector, e.g. `-k 2 2 2`. If not specified, the '
+    'k-points distance defined by the protocol is used instead.',
+)
+
+QPOINTS_MESH = OverridableOption(
+    '-q',
+    '--qpoints-mesh',
+    'qpoints_mesh',
+    nargs=3,
+    type=click.INT,
+    callback=validate.validate_kpoints_mesh,
+    help='The number of points in the q-point mesh along each basis vector, e.g. `-q 2 2 2`.',
+)
+
+QPOINTS_DISTANCE = OverridableOption(
+    '-Q',
+    '--qpoints-distance',
+    type=click.FLOAT,
+    required=False,
+    help='The minimum desired distance in 1/Å between q-points in reciprocal space.',
+)
+
+MAX_NUM_MACHINES = OverridableOption(
+    '-m',
+    '--max-num-machines',
+    type=click.INT,
+    required=False,
+    help='The maximum number of machines (nodes) to use for the calculations.',
+)
+
+MAX_WALLCLOCK_SECONDS = OverridableOption(
+    '-w',
+    '--max-wallclock-seconds',
+    type=click.INT,
+    required=False,
+    help='The maximum wallclock time in seconds to set for the calculations.',
+)
+
+WITH_MPI = OverridableOption(
+    '-i',
+    '--with-mpi/--without-mpi',
+    'with_mpi',
+    default=None,
+    help='Run the calculations with MPI enabled.',
+)
+
+DAEMON = OverridableOption(
+    '--daemon/--no-daemon',
+    '-D',
+    'daemon',
+    default=True,
+    show_default=True,
+    help='Submit the process to the daemon instead of running it and waiting for it to finish.',
+)
+
+CLEAN_WORKDIR = OverridableOption(
+    '-x',
+    '--clean-workdir/--no-clean-workdir',
+    'clean_workdir',
+    default=None,
+    help='Clean the remote folders of all the launched calculations after completion of the work chain. If not '
+    'specified, the value defined by the protocol is used.',
+)
+
+ELECTRONIC_TYPE = OverridableOption(
+    '--electronic-type',
+    type=EnumParamType(ElectronicType, exclude=('automatic',)),
+    default=ElectronicType.METAL.value,
+    show_default=True,
+    help='Select the electronic type of the system.',
+)
+
+SPIN_TYPE = OverridableOption(
+    '--spin-type',
+    type=EnumParamType(SpinType, exclude=('non_collinear', 'spin_orbit')),
+    default=SpinType.NONE.value,
+    show_default=True,
+    help='Select the spin polarization type of the system.',
+)
+
+RELAX_TYPE = OverridableOption(
+    '--relax-type',
+    type=EnumParamType(RelaxType, exclude=('volume', 'positions_volume')),
+    default=RelaxType.POSITIONS_CELL.value,
+    show_default=True,
+    help='Select what should be optimized by the geometry optimization steps.',
+)
+
+ONLY_INITIALIZATION = OverridableOption(
+    '--only-initialization',
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help='Only run the initialization step of the hp.x calculation, which determines the number of perturbations.',
+)
+
+PARALLELIZE_ATOMS = OverridableOption(
+    '--parallelize-atoms/--no-parallelize-atoms',
+    'parallelize_atoms',
+    default=None,
+    help='Parallelize the linear response calculation over the Hubbard atoms. If not specified, the value defined by '
+    'the protocol is used.',
+)
+
+PARALLELIZE_QPOINTS = OverridableOption(
+    '--parallelize-qpoints/--no-parallelize-qpoints',
+    'parallelize_qpoints',
+    default=None,
+    help='Parallelize the linear response calculation over the q-points. This requires the parallelization over the '
+    'Hubbard atoms to be enabled. If not specified, the value defined by the protocol is used.',
+)

--- a/src/aiida_hubbard/cli/utils/validate.py
+++ b/src/aiida_hubbard/cli/utils/validate.py
@@ -1,0 +1,33 @@
+"""Utility functions for validation of command line interface parameter inputs."""
+
+from aiida.cmdline.utils import decorators
+import click
+
+
+@decorators.with_dbenv()
+def validate_kpoints_mesh(ctx, param, value):
+    """Command line option validator for a kpoints mesh tuple.
+
+    The value should be a tuple of three positive integers out of which a ``KpointsData`` object will be created with a
+    mesh equal to the tuple.
+
+    :param ctx: internal context of the click.command
+    :param param: the click Parameter, i.e. either the Option or Argument to which the validator is hooked up
+    :param value: a tuple of three positive integers
+    :returns: a ``KpointsData`` instance
+    """
+    from aiida.orm import KpointsData
+
+    if not value:
+        return None
+
+    if any(not isinstance(integer, int) for integer in value) or any(int(i) <= 0 for i in value):
+        raise click.BadParameter('all values of the tuple should be positive greater than zero integers')
+
+    try:
+        kpoints = KpointsData()
+        kpoints.set_kpoints_mesh(value)
+    except ValueError as exception:
+        raise click.BadParameter(f'failed to create a KpointsData mesh out of {value}\n{exception}')
+
+    return kpoints

--- a/src/aiida_hubbard/cli/workflows/hp/__init__.py
+++ b/src/aiida_hubbard/cli/workflows/hp/__init__.py
@@ -1,0 +1,1 @@
+"""Module with CLI commands for the various ``hp`` work chain implementations."""

--- a/src/aiida_hubbard/cli/workflows/hp/base.py
+++ b/src/aiida_hubbard/cli/workflows/hp/base.py
@@ -1,52 +1,71 @@
 """Command line scripts to launch a `HpBaseWorkChain` for testing and demonstration purposes."""
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
-from aiida_quantumespresso.cli.utils import launch
-from aiida_quantumespresso.cli.utils import options as options_qe
 import click
+import yaml
 
+from ...utils import get_options, launch, options
 from .. import cmd_launch
 
 
 @cmd_launch.command('hp-base')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.hp'))
-@options_qe.KPOINTS_MESH(default=[1, 1, 1])
-@options_qe.PARENT_FOLDER()
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
-@options.DRY_RUN()
-@options_qe.CLEAN_WORKDIR()
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.hp'))
+@options.PARENT_FOLDER()
+@options.HUBBARD_STRUCTURE()
+@options.PROTOCOL()
+@options.OVERRIDES()
+@options.QPOINTS_MESH()
+@options.ONLY_INITIALIZATION()
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.CLEAN_WORKDIR()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_workflow(
-    code, kpoints_mesh, parent_folder, max_num_machines, max_wallclock_seconds, with_mpi, clean_workdir, daemon, dry_run
+    code,
+    parent_folder,
+    hubbard_structure,
+    protocol,
+    overrides,
+    qpoints_mesh,
+    only_initialization,
+    max_num_machines,
+    max_wallclock_seconds,
+    with_mpi,
+    clean_workdir,
+    daemon,
 ):
-    """Run a `HpBaseWorkChain`."""
-    from aiida import orm
+    """Run an `HpBaseWorkChain`."""
     from aiida.plugins import WorkflowFactory
-    from aiida_quantumespresso.utils.resources import get_default_options
 
-    parameters = {'INPUTHP': {}}
+    overrides = (yaml.safe_load(overrides) or {}) if overrides else {}
 
-    inputs = {
-        'hp': {
-            'code': code,
-            'qpoints': kpoints_mesh,
-            'parameters': orm.Dict(dict=parameters),
-            'parent_scf': parent_folder,
-            'metadata': {
-                'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi),
-            },
-        },
-        'clean_workdir': orm.Bool(clean_workdir),
-    }
+    if only_initialization:
+        if not hubbard_structure:
+            raise click.BadParameter(
+                'the `hp.x` initialization requires a `HubbardStructureData` to determine the perturbed atoms',
+                param_hint='--hubbard-structure',
+            )
+        overrides['only_initialization'] = True
 
-    if dry_run:
-        if daemon:
-            raise click.BadParameter('cannot send to the daemon if in dry_run mode', param_hint='--daemon')
-        inputs.setdefault('metadata', {})['store_provenance'] = False
-        inputs['metadata']['dry_run'] = True
+    if clean_workdir is not None:
+        overrides['clean_workdir'] = clean_workdir
 
-    launch.launch_process(WorkflowFactory('quantumespresso.hp.base'), daemon, **inputs)
+    if hubbard_structure:
+        overrides.setdefault('hp', {})['hubbard_structure'] = hubbard_structure
+
+    builder = WorkflowFactory('quantumespresso.hp.base').get_builder_from_protocol(
+        code=code,
+        protocol=protocol,
+        parent_scf_folder=parent_folder,
+        overrides=overrides or None,
+        options=get_options(max_num_machines, max_wallclock_seconds, with_mpi),
+    )
+
+    if qpoints_mesh:
+        builder.hp.qpoints = qpoints_mesh
+
+    launch.launch_process(builder, daemon)

--- a/src/aiida_hubbard/cli/workflows/hp/main.py
+++ b/src/aiida_hubbard/cli/workflows/hp/main.py
@@ -1,69 +1,81 @@
 """Command line scripts to launch a `HpWorkChain` for testing and demonstration purposes."""
 
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import options as options_core
+from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
-from aiida_quantumespresso.cli.utils import launch
-from aiida_quantumespresso.cli.utils import options as options_qe
-import click
+import yaml
 
+from ...utils import get_options, launch, options, validate_parallelization
 from .. import cmd_launch
 
 
 @cmd_launch.command('hp-main')
-@options.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.hp'))
-@options_qe.KPOINTS_MESH(default=[1, 1, 1])
-@options_qe.PARENT_FOLDER()
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
-@options.DRY_RUN()
-@options_qe.CLEAN_WORKDIR()
-@click.option(
-    '--parallelize-atoms',
-    is_flag=True,
-    default=False,
-    show_default=True,
-    help='Parallelize the linear response calculation over the Hubbard atoms.',
-)
+@options_core.CODE(required=True, type=types.CodeParamType(entry_point='quantumespresso.hp'))
+@options.PARENT_FOLDER()
+@options.HUBBARD_STRUCTURE()
+@options.PROTOCOL()
+@options.OVERRIDES()
+@options.QPOINTS_MESH()
+@options.QPOINTS_DISTANCE()
+@options.PARALLELIZE_ATOMS()
+@options.PARALLELIZE_QPOINTS()
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.CLEAN_WORKDIR()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_workflow(
     code,
-    kpoints_mesh,
     parent_folder,
+    hubbard_structure,
+    protocol,
+    overrides,
+    qpoints_mesh,
+    qpoints_distance,
+    parallelize_atoms,
+    parallelize_qpoints,
     max_num_machines,
     max_wallclock_seconds,
     with_mpi,
     clean_workdir,
-    parallelize_atoms,
     daemon,
-    dry_run,
 ):
-    """Run a `HpWorkChain`."""
-    from aiida import orm
+    """Run an `HpWorkChain`.
+
+    It computes the Hubbard parameters, optionally parallelizing the linear response calculation over the Hubbard
+    atoms and their perturbations (q-points).
+    """
     from aiida.plugins import WorkflowFactory
-    from aiida_quantumespresso.utils.resources import get_default_options
 
-    parameters = {'INPUTHP': {}}
+    overrides = (yaml.safe_load(overrides) or {}) if overrides else {}
+    parallelize_atoms, parallelize_qpoints = validate_parallelization(parallelize_atoms, parallelize_qpoints)
 
-    inputs = {
-        'hp': {
-            'code': code,
-            'qpoints': kpoints_mesh,
-            'parameters': orm.Dict(dict=parameters),
-            'parent_scf': parent_folder,
-            'metadata': {
-                'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi),
-            },
-        },
-        'parallelize_atoms': orm.Bool(parallelize_atoms),
-        'clean_workdir': orm.Bool(clean_workdir),
-    }
+    if qpoints_distance is not None:
+        overrides['qpoints_distance'] = qpoints_distance
 
-    if dry_run:
-        if daemon:
-            raise click.BadParameter('cannot send to the daemon if in dry_run mode', param_hint='--daemon')
-        inputs.setdefault('metadata', {})['store_provenance'] = False
-        inputs['metadata']['dry_run'] = True
+    if parallelize_atoms is not None:
+        overrides['parallelize_atoms'] = parallelize_atoms
 
-    launch.launch_process(WorkflowFactory('quantumespresso.hp.main'), daemon, **inputs)
+    if parallelize_qpoints is not None:
+        overrides['parallelize_qpoints'] = parallelize_qpoints
+
+    if clean_workdir is not None:
+        overrides['clean_workdir'] = clean_workdir
+
+    if hubbard_structure:
+        overrides.setdefault('hp', {})['hubbard_structure'] = hubbard_structure
+
+    builder = WorkflowFactory('quantumespresso.hp.main').get_builder_from_protocol(
+        code=code,
+        protocol=protocol,
+        parent_scf_folder=parent_folder,
+        overrides=overrides or None,
+        options=get_options(max_num_machines, max_wallclock_seconds, with_mpi),
+    )
+
+    if qpoints_mesh:
+        builder.pop('qpoints_distance', None)
+        builder.qpoints = qpoints_mesh
+
+    launch.launch_process(builder, daemon)

--- a/src/aiida_hubbard/cli/workflows/hubbard.py
+++ b/src/aiida_hubbard/cli/workflows/hubbard.py
@@ -1,153 +1,139 @@
 """Command line scripts to launch a `SelfConsistentHubbardWorkChain` for testing and demonstration purposes."""
 
-from aiida.cmdline.params import types
 from aiida.cmdline.utils import decorators
-from aiida_quantumespresso.cli.utils import launch
-from aiida_quantumespresso.cli.utils import options as options_qe
 import click
+import yaml
 
+from ..utils import defaults, get_options, launch, options, validate_parallelization
 from . import cmd_launch
 
 
 @cmd_launch.command('hubbard')
+@options.PW_CODE()
+@options.HP_CODE()
+@options.HUBBARD_STRUCTURE(
+    default=defaults.get_hubbard_structure,
+    help='A HubbardStructureData node identified by its ID or UUID, with initialized Hubbard parameters. If not '
+    'specified, a bulk LiCoO2 structure with an initialized on-site Hubbard U on cobalt is used.',
+)
+@options.PROTOCOL()
+@options.OVERRIDES()
+@options.PSEUDO_FAMILY()
+@options.KPOINTS_MESH()
+@options.QPOINTS_MESH()
+@options.ELECTRONIC_TYPE()
+@options.SPIN_TYPE()
+@options.RELAX_TYPE()
 @click.option(
-    '--pw',
-    'code_pw',
-    type=types.CodeParamType(entry_point='quantumespresso.pw'),
-    required=True,
-    help='The code to use for the pw.x executable.',
+    '--relax/--no-relax',
+    'relax',
+    default=True,
+    show_default=True,
+    help='Iteratively relax the structure with the `PwRelaxWorkChain` during the self-consistent cycle.',
 )
 @click.option(
-    '--hp',
-    'code_hp',
-    type=types.CodeParamType(entry_point='quantumespresso.hp'),
-    required=True,
-    help='The code to use for the hp.x executable.',
-)
-@options_qe.STRUCTURE()
-@options_qe.PSEUDO_FAMILY()
-@options_qe.KPOINTS_MESH(required=True, help='The k-point mesh to use for the SCF calculations.')
-@options_qe.QPOINTS_MESH(required=True, help='The q-point mesh to use for the linear response calculation.')
-@options_qe.ECUTWFC()
-@options_qe.ECUTRHO()
-@options_qe.HUBBARD_U(required=True)
-@options_qe.STARTING_MAGNETIZATION()
-@options_qe.MAX_NUM_MACHINES()
-@options_qe.MAX_WALLCLOCK_SECONDS()
-@options_qe.WITH_MPI()
-@options_qe.DAEMON()
-@click.option(
-    '--meta-convergence', is_flag=True, default=False, help='Switch on the meta-convergence for the Hubbard parameters.'
+    '--init-relax/--no-init-relax',
+    'init_relax',
+    default=True,
+    show_default=True,
+    help='Prepend a relaxation with looser thresholds to each relaxation step.',
 )
 @click.option(
-    '--parallelize-atoms',
-    is_flag=True,
-    default=False,
-    help='Parallelize the linear response calculation over the Hubbard atoms.',
+    '--meta-convergence/--no-meta-convergence',
+    'meta_convergence',
+    default=None,
+    help='Run the self-consistent cycle until the Hubbard parameters are converged. If not specified, the value '
+    'defined by the protocol is used.',
 )
+@options.PARALLELIZE_ATOMS()
+@options.PARALLELIZE_QPOINTS()
+@options.MAX_NUM_MACHINES()
+@options.MAX_WALLCLOCK_SECONDS()
+@options.WITH_MPI()
+@options.CLEAN_WORKDIR()
+@options.DAEMON()
 @decorators.with_dbenv()
 def launch_workflow(
-    code_pw,
-    code_hp,
-    structure,
+    pw_code,
+    hp_code,
+    hubbard_structure,
+    protocol,
+    overrides,
     pseudo_family,
     kpoints_mesh,
     qpoints_mesh,
-    ecutwfc,
-    ecutrho,
-    hubbard_u,
-    starting_magnetization,
-    max_num_machines,
-    max_wallclock_seconds,
-    daemon,
+    electronic_type,
+    spin_type,
+    relax_type,
+    relax,
+    init_relax,
     meta_convergence,
     parallelize_atoms,
+    parallelize_qpoints,
+    max_num_machines,
+    max_wallclock_seconds,
     with_mpi,
+    clean_workdir,
+    daemon,
 ):
-    """Run the `SelfConsistentHubbardWorkChain` for a given input structure."""
-    from aiida import orm
+    """Run a `SelfConsistentHubbardWorkChain`.
+
+    It computes the self-consistent Hubbard parameters of the given `HubbardStructureData`, iterating a
+    (relax-)scf-hp cycle until the Hubbard parameters are converged within the tolerances of the protocol.
+    """
     from aiida.plugins import WorkflowFactory
-    from aiida_quantumespresso.utils.resources import get_default_options
 
-    cutoff_wfc, cutoff_rho = pseudo_family.get_recommended_cutoffs(structure=structure)
+    overrides = (yaml.safe_load(overrides) or {}) if overrides else {}
+    parallelize_atoms, parallelize_qpoints = validate_parallelization(parallelize_atoms, parallelize_qpoints)
 
-    parameters = {
-        'SYSTEM': {
-            'ecutwfc': ecutwfc or cutoff_wfc,
-            'ecutrho': ecutrho or cutoff_rho,
-            'lda_plus_u': True,
-        },
-        'ELECTRONS': {
-            'mixing_beta': 0.4,
-        },
-    }
+    if pseudo_family:
+        overrides.setdefault('scf', {})['pseudo_family'] = pseudo_family.label
+        relax_overrides = overrides.setdefault('relax', {})
+        relax_overrides.setdefault('base_relax', {})['pseudo_family'] = pseudo_family.label
+        relax_overrides.setdefault('base_init_relax', {})['pseudo_family'] = pseudo_family.label
 
-    parameters_hp = {'INPUTHP': {}}
+    if meta_convergence is not None:
+        overrides['meta_convergence'] = meta_convergence
 
-    structure_kinds = structure.get_kind_names()
-    hubbard_u_kinds = [kind for kind, value in hubbard_u]
+    if clean_workdir is not None:
+        overrides['clean_workdir'] = clean_workdir
 
-    if not set(hubbard_u_kinds).issubset(structure_kinds):
-        raise click.BadParameter(
-            f'the kinds in the specified starting Hubbard U values {hubbard_u_kinds} is not a strict subset of the '
-            f'kinds in the structure {structure_kinds}',
-            param_hint='hubbard_u',
-        )
+    if parallelize_atoms is not None:
+        overrides.setdefault('hubbard', {})['parallelize_atoms'] = parallelize_atoms
 
-    if starting_magnetization:
-        parameters['SYSTEM']['nspin'] = 2
+    if parallelize_qpoints is not None:
+        overrides.setdefault('hubbard', {})['parallelize_qpoints'] = parallelize_qpoints
 
-        for kind, magnetization in starting_magnetization:
-            if kind not in structure_kinds:
-                raise click.BadParameter(
-                    f'the provided structure does not contain the kind {kind}', param_hint='starting_magnetization'
-                )
+    builder = WorkflowFactory('quantumespresso.hp.hubbard').get_builder_from_protocol(
+        pw_code=pw_code,
+        hp_code=hp_code,
+        hubbard_structure=hubbard_structure,
+        protocol=protocol,
+        overrides=overrides or None,
+        options_pw=get_options(max_num_machines, max_wallclock_seconds, with_mpi),
+        options_hp=get_options(max_num_machines, max_wallclock_seconds, with_mpi),
+        electronic_type=electronic_type,
+        spin_type=spin_type,
+        relax_type=relax_type,
+    )
 
-            parameters['SYSTEM'].setdefault('starting_magnetization', {})[kind] = magnetization
+    if not relax:
+        builder.pop('relax', None)
+    elif not init_relax:
+        builder.relax.pop('base_init_relax', None)
 
-    inputs = {
-        'structure': structure,
-        'hubbard_u': orm.Dict(dict=dict(hubbard_u)),
-        'meta_convergence': orm.Bool(meta_convergence),
-        'recon': {
-            'kpoints': kpoints_mesh,
-            'pw': {
-                'code': code_pw,
-                'pseudos': pseudo_family.get_pseudos(structure=structure),
-                'parameters': orm.Dict(dict=parameters),
-                'metadata': {'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)},
-            },
-        },
-        'relax': {
-            'meta_convergence': orm.Bool(False),
-            'base': {
-                'kpoints': kpoints_mesh,
-                'pw': {
-                    'code': code_pw,
-                    'pseudos': pseudo_family.get_pseudos(structure=structure),
-                    'parameters': orm.Dict(dict=parameters),
-                    'metadata': {'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)},
-                },
-            },
-        },
-        'scf': {
-            'kpoints': kpoints_mesh,
-            'pw': {
-                'code': code_pw,
-                'pseudos': pseudo_family.get_pseudos(structure=structure),
-                'parameters': orm.Dict(dict=parameters),
-                'metadata': {'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)},
-            },
-        },
-        'hubbard': {
-            'hp': {
-                'code': code_hp,
-                'qpoints': qpoints_mesh,
-                'parameters': orm.Dict(dict=parameters_hp),
-                'metadata': {'options': get_default_options(max_num_machines, max_wallclock_seconds, with_mpi)},
-            },
-            'parallelize_atoms': orm.Bool(parallelize_atoms),
-        },
-    }
+    if kpoints_mesh:
+        builder.scf.pop('kpoints_distance', None)
+        builder.scf.kpoints = kpoints_mesh
 
-    launch.launch_process(WorkflowFactory('quantumespresso.hp.hubbard'), daemon, **inputs)
+        if 'relax' in builder:
+            for namespace in ('base_init_relax', 'base_relax'):
+                if namespace in builder.relax:
+                    builder.relax[namespace].pop('kpoints_distance', None)
+                    builder.relax[namespace].kpoints = kpoints_mesh
+
+    if qpoints_mesh:
+        builder.hubbard.pop('qpoints_distance', None)
+        builder.hubbard.qpoints = qpoints_mesh
+
+    launch.launch_process(builder, daemon)

--- a/src/aiida_hubbard/workflows/hubbard.py
+++ b/src/aiida_hubbard/workflows/hubbard.py
@@ -124,7 +124,7 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
         spec.input('relax_frequency', valid_type=orm.Int, required=False, validator=validate_positive,
             help='Integer value referring to the number of iterations to wait before performing the `relax` step.')
         spec.expose_inputs(PwRelaxWorkChain, namespace='relax',
-            exclude=('clean_workdir', 'structure', 'base_final_scf'),
+            exclude=('clean_workdir', 'structure'),
             namespace_options={'required': False, 'populate_defaults': False,
                 'help': 'Inputs for the `PwRelaxWorkChain` that, when defined, will iteratively relax the structure.'})
         spec.expose_inputs(PwBaseWorkChain, namespace='scf',
@@ -242,7 +242,6 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
 
         relax.pop('clean_workdir')
         relax.pop('structure')
-        relax.pop('base_final_scf', None)  # We do not want to run a final scf, since it would be time wasted.
         scf.pop('clean_workdir')
         scf['pw'].pop('structure')
 
@@ -383,11 +382,13 @@ class SelfConsistentHubbardWorkChain(WorkChain, ProtocolMixin):
             inputs.pw.structure = self.ctx.current_hubbard_structure
 
         elif cls is PwRelaxWorkChain and namespace == 'relax':
-            inputs.base = self.set_pw_parameters(inputs.base)
-            # inputs.base.pw.parameters.setdefault('IONS', {})
             inputs.structure = self.ctx.current_hubbard_structure
-            inputs.base.pw.pseudos = pseudos
-            inputs.pop('base_final_scf', None)  # We do not want to run a final scf, since it would be time wasted.
+            if 'base_init_relax' in inputs:
+                inputs.base_init_relax = self.set_pw_parameters(inputs.base_init_relax)
+                inputs.base_init_relax.pw.pseudos = pseudos
+            inputs.base_relax = self.set_pw_parameters(inputs.base_relax)
+            # inputs.base_relax.pw.parameters.setdefault('IONS', {})
+            inputs.base_relax.pw.pseudos = pseudos
 
         return inputs
 

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the command line interface."""

--- a/tests/cli/calculations/__init__.py
+++ b/tests/cli/calculations/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the CLI commands of the calculation job implementations."""

--- a/tests/cli/calculations/test_hp.py
+++ b/tests/cli/calculations/test_hp.py
@@ -1,0 +1,120 @@
+"""Tests for the ``calculation launch hp`` command."""
+
+from aiida_hubbard.cli.calculations.hp import launch_calculation
+
+
+def test_command_hp(run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes):
+    """Test invoking the calculation launch command with only required inputs."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk)]
+    run_cli_process_launch_command(launch_calculation, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.code.uuid == code.uuid
+    assert inputs.parent_scf.uuid == parent_scf.uuid
+    assert inputs.qpoints.get_kpoints_mesh() == ([1, 1, 1], [0.0, 0.0, 0.0])
+    assert inputs.parameters.get_dict() == {'INPUTHP': {}}
+
+
+def test_command_hp_qpoints_mesh(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the calculation launch command with an explicit q-points mesh."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-q', '2', '2', '2']
+    run_cli_process_launch_command(launch_calculation, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.qpoints.get_kpoints_mesh() == ([2, 2, 2], [0.0, 0.0, 0.0])
+
+
+def test_command_hp_hubbard_structure(
+    run_cli_process_launch_command,
+    fixture_code,
+    generate_hubbard_structure,
+    generate_parent_scf_folder,
+    launched_processes,
+):
+    """Test invoking the calculation launch command with an explicit ``HubbardStructureData``."""
+    code = fixture_code('quantumespresso.hp').store()
+    hubbard_structure = generate_hubbard_structure().store()
+    parent_scf = generate_parent_scf_folder(hubbard_structure=hubbard_structure)
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-S', str(hubbard_structure.pk)]
+    run_cli_process_launch_command(launch_calculation, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.hubbard_structure.uuid == hubbard_structure.uuid
+
+
+def test_command_hp_options(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the calculation launch command with the computational resource options."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-m', '2', '-w', '3600', '--with-mpi']
+    run_cli_process_launch_command(launch_calculation, options=options)
+
+    metadata_options = launched_processes[0].node.get_options()
+    assert metadata_options['resources']['num_machines'] == 2
+    assert metadata_options['max_wallclock_seconds'] == 3600
+    assert metadata_options['withmpi'] is True
+
+
+def test_command_hp_dry_run(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the calculation launch command with the ``--dry-run`` option."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '--dry-run']
+    run_cli_process_launch_command(launch_calculation, options=options)
+
+    assert launched_processes[0].metadata.dry_run is True
+
+
+def test_command_hp_dry_run_creates_input_file(
+    run_cli_command, fixture_code, generate_parent_scf_folder, tmp_path, monkeypatch
+):
+    """Test that an actual dry run, i.e. without mocking the engine, writes the ``hp.x`` input file."""
+    monkeypatch.chdir(tmp_path)
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-q', '2', '2', '2', '--dry-run']
+    result = run_cli_command(launch_calculation, options=options)
+
+    assert 'Running a dry run for HpCalculation' in result.output
+
+    filepaths_input = list(tmp_path.glob('submit_test/*/aiida.in'))
+    assert len(filepaths_input) == 1
+
+    content = filepaths_input[0].read_text()
+    assert '&INPUTHP' in content
+    assert 'nq1' in content
+
+
+def test_command_hp_dry_run_daemon(run_cli_command, fixture_code, generate_parent_scf_folder):
+    """Test that the ``--dry-run`` and ``--daemon`` options are mutually exclusive."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '--dry-run', '--daemon']
+    result = run_cli_command(launch_calculation, options=options, raises=True)
+    assert 'daemon' in result.output
+
+
+def test_command_hp_parent_folder_required(run_cli_command, fixture_code):
+    """Test that the ``--parent-folder`` option is required."""
+    code = fixture_code('quantumespresso.hp').store()
+
+    options = ['-X', code.full_label]
+    result = run_cli_command(launch_calculation, options=options, raises=True)
+    assert '--parent-folder' in result.output

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,114 @@
+"""Fixtures for the command line interface."""
+
+import pytest
+
+
+@pytest.fixture
+def filepath_cli_fixtures(filepath_tests):
+    """Return the filepath of the directory containing the CLI test fixtures."""
+    from pathlib import Path
+
+    return Path(filepath_tests, 'cli', 'fixtures')
+
+
+@pytest.fixture
+def run_cli_command():
+    """Run a `click` command with the given options.
+
+    The call will raise if the command triggered an exception or the exit code returned is non-zero.
+    """
+
+    def _run_cli_command(command, options=None, raises=None):
+        """Run the command and check the result.
+
+        :param command: the command to invoke
+        :param options: the list of command line options to pass to the command invocation
+        :param raises: optionally an exception class that is expected to be raised
+        """
+        import traceback
+
+        from click.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(command, options or [])
+
+        if raises is not None:
+            assert result.exception is not None, result.output
+            assert result.exit_code != 0
+        else:
+            assert result.exception is None, ''.join(traceback.format_exception(*result.exc_info))
+            assert result.exit_code == 0, result.output
+
+        result.output_lines = [line.strip() for line in result.output.split('\n') if line.strip()]
+
+        return result
+
+    return _run_cli_command
+
+
+@pytest.fixture
+def launched_processes():
+    """Return the list into which ``run_cli_process_launch_command`` records the launched process instances."""
+    return []
+
+
+@pytest.fixture
+def run_cli_process_launch_command(run_cli_command, launched_processes, monkeypatch):
+    """Run a process launch command with the given options.
+
+    Instead of mocking :meth:`~aiida_hubbard.cli.utils.launch.launch_process` into a no-op, the actual engine launch
+    functions are monkeypatched. This way the inputs that the command constructs are still fully validated against the
+    process specification -- exactly as they would be upon a real submission -- without any calculation being run. The
+    instantiated processes are recorded in the ``launched_processes`` fixture such that tests can assert on the inputs.
+
+    The call will raise if the command triggered an exception or the exit code returned is non-zero.
+
+    :param command: the command to invoke
+    :param options: the list of command line options to pass to the command invocation
+    :param raises: optionally an exception class that is expected to be raised
+    """
+
+    def _instantiate(process, **inputs):
+        """Instantiate the process, validating the inputs, and record it in ``launched_processes``."""
+        from aiida.engine.utils import instantiate_process
+        from aiida.manage import get_manager
+
+        instance = instantiate_process(get_manager().get_runner(), process, **inputs)
+        launched_processes.append(instance)
+        return instance
+
+    def _mock_submit(process, **inputs):
+        """Mock of :meth:`aiida.engine.launch.submit` that validates the inputs instead of submitting."""
+        return _instantiate(process, **inputs).node
+
+    def _mock_run_get_node(process, **inputs):
+        """Mock of :meth:`aiida.engine.launch.run_get_node` that validates the inputs instead of running."""
+        node = _instantiate(process, **inputs).node
+
+        if inputs.get('metadata', {}).get('dry_run', False):
+            # Emulate what the engine sets on the node for an actual dry run of a ``CalcJob``.
+            node.dry_run_info = {'folder': '.', 'script_filename': '_aiidasubmit.sh'}
+
+        return {}, node
+
+    def _inner(command, options=None, raises=None):
+        """Run the command and check the result."""
+        from aiida.engine import launch
+
+        monkeypatch.setattr(launch, 'submit', _mock_submit)
+        monkeypatch.setattr(launch, 'run_get_node', _mock_run_get_node)
+        return run_cli_command(command, options, raises)
+
+    return _inner
+
+
+@pytest.fixture
+def generate_parent_scf_folder(generate_calc_job_node, generate_inputs_pw, generate_hubbard_structure):
+    """Return a ``RemoteData`` that is a valid ``parent_scf`` input for an ``HpCalculation``."""
+
+    def _generate_parent_scf_folder(hubbard_structure=None):
+        """Return a ``RemoteData`` that is a valid ``parent_scf`` input for an ``HpCalculation``."""
+        inputs = generate_inputs_pw(structure=hubbard_structure or generate_hubbard_structure())
+        return generate_calc_job_node('quantumespresso.pw', inputs=inputs).outputs.remote_folder
+
+    return _generate_parent_scf_folder

--- a/tests/cli/fixtures/overrides/hp-base.yaml
+++ b/tests/cli/fixtures/overrides/hp-base.yaml
@@ -1,0 +1,5 @@
+clean_workdir: false
+hp:
+  parameters:
+    INPUTHP:
+      conv_thr_chi: 1.0e-3

--- a/tests/cli/fixtures/overrides/hp-main.yaml
+++ b/tests/cli/fixtures/overrides/hp-main.yaml
@@ -1,0 +1,5 @@
+qpoints_distance: 1.5
+hp:
+  parameters:
+    INPUTHP:
+      conv_thr_chi: 1.0e-3

--- a/tests/cli/fixtures/overrides/hubbard.yaml
+++ b/tests/cli/fixtures/overrides/hubbard.yaml
@@ -1,0 +1,4 @@
+tolerance_onsite: 0.5
+max_iterations: 3
+scf:
+  kpoints_distance: 1.0

--- a/tests/cli/test_commands.py
+++ b/tests/cli/test_commands.py
@@ -32,6 +32,34 @@ def recurse_commands(command: click.Command, parents: list[str] = None):
         yield [command.name]
 
 
+def test_commands_available():
+    """Test that all expected commands are registered with the CLI."""
+    expected = [
+        ['aiida-hubbard'],
+        ['aiida-hubbard', 'calculation'],
+        ['aiida-hubbard', 'calculation', 'launch'],
+        ['aiida-hubbard', 'calculation', 'launch', 'hp'],
+        ['aiida-hubbard', 'workflow'],
+        ['aiida-hubbard', 'workflow', 'launch'],
+        ['aiida-hubbard', 'workflow', 'launch', 'hp-base'],
+        ['aiida-hubbard', 'workflow', 'launch', 'hp-main'],
+        ['aiida-hubbard', 'workflow', 'launch', 'hubbard'],
+    ]
+    assert sorted(recurse_commands(cmd_root)) == sorted(expected)
+
+
+def test_commands_protocols():
+    """Test that the protocols exposed by the CLI match those implemented by the work chains."""
+    from aiida_hubbard.cli.utils.options import DEFAULT_PROTOCOL, PROTOCOLS
+    from aiida_hubbard.workflows.hp.base import HpBaseWorkChain
+    from aiida_hubbard.workflows.hp.main import HpWorkChain
+    from aiida_hubbard.workflows.hubbard import SelfConsistentHubbardWorkChain
+
+    for cls in (HpBaseWorkChain, HpWorkChain, SelfConsistentHubbardWorkChain):
+        assert sorted(cls.get_available_protocols()) == sorted(PROTOCOLS)
+        assert cls.get_default_protocol() == DEFAULT_PROTOCOL
+
+
 @pytest.mark.parametrize('command', recurse_commands(cmd_root))
 @pytest.mark.parametrize('help_option', ('--help', '-h'))
 def test_commands_help_option(command, help_option):

--- a/tests/cli/workflows/__init__.py
+++ b/tests/cli/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the CLI commands of the work chain implementations."""

--- a/tests/cli/workflows/hp/__init__.py
+++ b/tests/cli/workflows/hp/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the CLI commands of the ``hp`` work chain implementations."""

--- a/tests/cli/workflows/hp/test_base.py
+++ b/tests/cli/workflows/hp/test_base.py
@@ -1,0 +1,146 @@
+"""Tests for the ``workflow launch hp-base`` command."""
+
+from pathlib import Path
+
+from aiida_hubbard.cli.workflows.hp.base import launch_workflow
+
+
+def test_command_hp_base(run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes):
+    """Test invoking the workflow launch command with only required inputs."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk)]
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.hp.code.uuid == code.uuid
+    assert inputs.hp.parent_scf.uuid == parent_scf.uuid
+    # These are the values of the default ``balanced`` protocol of the ``HpBaseWorkChain``.
+    assert inputs.hp.qpoints.get_kpoints_mesh() == ([2, 2, 2], [0.0, 0.0, 0.0])
+    assert inputs.hp.parameters['INPUTHP']['conv_thr_chi'] == 5e-6
+    assert inputs.clean_workdir.value is True
+    assert inputs.only_initialization.value is False
+
+
+def test_command_hp_base_protocol(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with the ``--protocol`` option."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-p', 'fast']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.hp.qpoints.get_kpoints_mesh() == ([1, 1, 1], [0.0, 0.0, 0.0])
+    assert inputs.hp.parameters['INPUTHP']['conv_thr_chi'] == 1e-4
+
+
+def test_command_hp_base_overrides(
+    run_cli_process_launch_command,
+    fixture_code,
+    generate_parent_scf_folder,
+    filepath_cli_fixtures,
+    launched_processes,
+):
+    """Test invoking the workflow launch command with the ``--overrides`` option."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+    filepath_overrides = Path(filepath_cli_fixtures, 'overrides', 'hp-base.yaml')
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-o', str(filepath_overrides)]
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.hp.parameters['INPUTHP']['conv_thr_chi'] == 1e-3
+    assert inputs.clean_workdir.value is False
+
+
+def test_command_hp_base_qpoints_mesh(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with an explicit q-points mesh."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-q', '4', '4', '4']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.hp.qpoints.get_kpoints_mesh() == ([4, 4, 4], [0.0, 0.0, 0.0])
+
+
+def test_command_hp_base_only_initialization(
+    run_cli_process_launch_command,
+    fixture_code,
+    generate_hubbard_structure,
+    generate_parent_scf_folder,
+    launched_processes,
+):
+    """Test invoking the workflow launch command with the ``--only-initialization`` option."""
+    code = fixture_code('quantumespresso.hp').store()
+    hubbard_structure = generate_hubbard_structure().store()
+    parent_scf = generate_parent_scf_folder(hubbard_structure=hubbard_structure)
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-S', str(hubbard_structure.pk)]
+    options.append('--only-initialization')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.only_initialization.value is True
+    assert inputs.hp.hubbard_structure.uuid == hubbard_structure.uuid
+
+
+def test_command_hp_base_only_initialization_no_structure(run_cli_command, fixture_code, generate_parent_scf_folder):
+    """Test that ``--only-initialization`` requires an explicit ``HubbardStructureData``."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '--only-initialization']
+    result = run_cli_command(launch_workflow, options=options, raises=True)
+    assert '--hubbard-structure' in result.output
+
+
+def test_command_hp_base_options(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with the computational resource options."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-m', '3', '-w', '600', '--without-mpi']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    metadata_options = launched_processes[0].inputs.hp.metadata['options']
+    assert metadata_options['resources']['num_machines'] == 3
+    assert metadata_options['max_wallclock_seconds'] == 600
+    assert metadata_options['withmpi'] is False
+
+
+def test_command_hp_base_no_daemon(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with the ``--no-daemon`` option."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '--no-daemon']
+    result = run_cli_process_launch_command(launch_workflow, options=options)
+
+    assert 'Running a HpBaseWorkChain' in result.output
+    assert f'HpBaseWorkChain<{launched_processes[0].node.pk}>' in result.output
+
+
+def test_command_hp_base_clean_workdir(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with the ``--no-clean-workdir`` option."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '--no-clean-workdir']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    assert launched_processes[0].inputs.clean_workdir.value is False

--- a/tests/cli/workflows/hp/test_main.py
+++ b/tests/cli/workflows/hp/test_main.py
@@ -1,0 +1,171 @@
+"""Tests for the ``workflow launch hp-main`` command."""
+
+from pathlib import Path
+
+from aiida_hubbard.cli.workflows.hp.main import launch_workflow
+
+
+def test_command_hp_main(run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes):
+    """Test invoking the workflow launch command with only required inputs."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk)]
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.hp.code.uuid == code.uuid
+    assert inputs.hp.parent_scf.uuid == parent_scf.uuid
+    # These are the values of the default ``balanced`` protocol of the ``HpWorkChain``.
+    assert inputs.qpoints_distance.value == 0.8
+    assert inputs.parallelize_atoms.value is True
+    assert inputs.parallelize_qpoints.value is True
+    assert inputs.clean_workdir.value is True
+    # The ``qpoints`` of the ``HpBaseWorkChain`` namespace are excluded by the ``HpWorkChain``.
+    assert 'qpoints' not in inputs.hp
+
+
+def test_command_hp_main_protocol(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with the ``--protocol`` option."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-p', 'fast']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.qpoints_distance.value == 1.2
+    assert inputs.hp.parameters['INPUTHP']['conv_thr_chi'] == 1e-4
+
+
+def test_command_hp_main_overrides(
+    run_cli_process_launch_command,
+    fixture_code,
+    generate_parent_scf_folder,
+    filepath_cli_fixtures,
+    launched_processes,
+):
+    """Test invoking the workflow launch command with the ``--overrides`` option."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+    filepath_overrides = Path(filepath_cli_fixtures, 'overrides', 'hp-main.yaml')
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-o', str(filepath_overrides)]
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.qpoints_distance.value == 1.5
+    assert inputs.hp.parameters['INPUTHP']['conv_thr_chi'] == 1e-3
+
+
+def test_command_hp_main_qpoints_mesh(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with an explicit q-points mesh."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-q', '4', '4', '4']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.qpoints.get_kpoints_mesh() == ([4, 4, 4], [0.0, 0.0, 0.0])
+    assert 'qpoints_distance' not in inputs
+
+
+def test_command_hp_main_qpoints_distance(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with an explicit q-points distance."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-Q', '0.4']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.qpoints_distance.value == 0.4
+    assert 'qpoints' not in inputs
+
+
+def test_command_hp_main_parallelization(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with the parallelization options."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = [
+        '-X',
+        code.full_label,
+        '-P',
+        str(parent_scf.pk),
+        '--no-parallelize-atoms',
+        '--no-parallelize-qpoints',
+    ]
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.parallelize_atoms.value is False
+    assert inputs.parallelize_qpoints.value is False
+
+
+def test_command_hp_main_parallelization_implied(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test that disabling the atom parallelization implies disabling the q-point parallelization."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '--no-parallelize-atoms']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.parallelize_atoms.value is False
+    assert inputs.parallelize_qpoints.value is False
+
+
+def test_command_hp_main_parallelization_invalid(run_cli_command, fixture_code, generate_parent_scf_folder):
+    """Test that q-point parallelization cannot be requested without atom parallelization."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '--no-parallelize-atoms', '--parallelize-qpoints']
+    result = run_cli_command(launch_workflow, options=options, raises=True)
+    assert '--parallelize-qpoints' in result.output
+
+
+def test_command_hp_main_hubbard_structure(
+    run_cli_process_launch_command,
+    fixture_code,
+    generate_hubbard_structure,
+    generate_parent_scf_folder,
+    launched_processes,
+):
+    """Test invoking the workflow launch command with an explicit ``HubbardStructureData``."""
+    code = fixture_code('quantumespresso.hp').store()
+    hubbard_structure = generate_hubbard_structure().store()
+    parent_scf = generate_parent_scf_folder(hubbard_structure=hubbard_structure)
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-S', str(hubbard_structure.pk)]
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    assert launched_processes[0].inputs.hp.hubbard_structure.uuid == hubbard_structure.uuid
+
+
+def test_command_hp_main_options(
+    run_cli_process_launch_command, fixture_code, generate_parent_scf_folder, launched_processes
+):
+    """Test invoking the workflow launch command with the computational resource options."""
+    code = fixture_code('quantumespresso.hp').store()
+    parent_scf = generate_parent_scf_folder()
+
+    options = ['-X', code.full_label, '-P', str(parent_scf.pk), '-m', '3', '-w', '600', '--without-mpi']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    metadata_options = launched_processes[0].inputs.hp.metadata['options']
+    assert metadata_options['resources']['num_machines'] == 3
+    assert metadata_options['max_wallclock_seconds'] == 600
+    assert metadata_options['withmpi'] is False

--- a/tests/cli/workflows/test_hubbard.py
+++ b/tests/cli/workflows/test_hubbard.py
@@ -1,0 +1,272 @@
+"""Tests for the ``workflow launch hubbard`` command."""
+
+from pathlib import Path
+
+import pytest
+
+from aiida_hubbard.cli.workflows.hubbard import launch_workflow
+
+
+@pytest.fixture
+def generate_options(fixture_code, generate_hubbard_structure):
+    """Return the minimally required command line options for the ``hubbard`` launch command."""
+
+    def _generate_options(*args):
+        pw_code = fixture_code('quantumespresso.pw').store()
+        hp_code = fixture_code('quantumespresso.hp').store()
+        hubbard_structure = generate_hubbard_structure().store()
+
+        options = [
+            '--pw',
+            pw_code.full_label,
+            '--hp',
+            hp_code.full_label,
+            '-S',
+            str(hubbard_structure.pk),
+            '-p',
+            'fast',
+        ]
+        options.extend(args)
+
+        return options
+
+    return _generate_options
+
+
+def test_command_hubbard(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with only required inputs."""
+    options = generate_options()
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+
+    # The stale inputs of the legacy CLI should no longer be part of the constructed inputs.
+    for key in ('structure', 'hubbard_u', 'recon'):
+        assert key not in inputs
+
+    # The ``relax`` namespace of the ``PwRelaxWorkChain`` in ``aiida-quantumespresso~=5.0``.
+    assert 'base_relax' in inputs.relax
+    assert 'base_init_relax' in inputs.relax
+    assert 'base' not in inputs.relax
+    assert 'base_final_scf' not in inputs.relax
+
+    assert 'hubbard_structure' in inputs
+    assert 'pw' in inputs.scf
+    assert 'hp' in inputs.hubbard
+
+    # These are the values of the ``fast`` protocol of the ``SelfConsistentHubbardWorkChain``.
+    assert inputs.tolerance_onsite.value == 0.2
+    assert inputs.tolerance_intersite.value == 0.1
+    assert inputs.scf.kpoints_distance.value == 0.6
+    assert inputs.meta_convergence.value is True
+    assert inputs.clean_workdir.value is True
+
+
+def test_command_hubbard_codes(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test that the ``--pw`` and ``--hp`` codes end up in the correct namespaces."""
+    options = generate_options()
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    pw_code_label = options[1]
+    hp_code_label = options[3]
+
+    assert inputs.scf.pw.code.full_label == pw_code_label
+    assert inputs.relax.base_relax.pw.code.full_label == pw_code_label
+    assert inputs.relax.base_init_relax.pw.code.full_label == pw_code_label
+    assert inputs.hubbard.hp.code.full_label == hp_code_label
+
+
+def test_command_hubbard_default_structure(run_cli_process_launch_command, fixture_code, launched_processes):
+    """Test invoking the workflow launch command without an explicit structure."""
+    from aiida_quantumespresso.data.hubbard_structure import HubbardStructureData
+
+    pw_code = fixture_code('quantumespresso.pw').store()
+    hp_code = fixture_code('quantumespresso.hp').store()
+
+    options = ['--pw', pw_code.full_label, '--hp', hp_code.full_label, '-p', 'fast']
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    hubbard_structure = launched_processes[0].inputs.hubbard_structure
+    assert isinstance(hubbard_structure, HubbardStructureData)
+    assert len(hubbard_structure.hubbard.parameters) > 0
+
+
+def test_command_hubbard_no_relax(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with the ``--no-relax`` option."""
+    options = generate_options('--no-relax')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    assert 'relax' not in launched_processes[0].inputs
+
+
+def test_command_hubbard_no_init_relax(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with the ``--no-init-relax`` option."""
+    options = generate_options('--no-init-relax')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert 'base_relax' in inputs.relax
+    assert 'base_init_relax' not in inputs.relax
+
+
+def test_command_hubbard_kpoints_mesh(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with an explicit k-points mesh."""
+    options = generate_options('-k', '2', '2', '2')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    mesh = ([2, 2, 2], [0.0, 0.0, 0.0])
+
+    assert 'kpoints_distance' not in inputs.scf
+    assert inputs.scf.kpoints.get_kpoints_mesh() == mesh
+    assert inputs.relax.base_relax.kpoints.get_kpoints_mesh() == mesh
+    assert inputs.relax.base_init_relax.kpoints.get_kpoints_mesh() == mesh
+
+
+def test_command_hubbard_kpoints_mesh_no_relax(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test that an explicit k-points mesh can be combined with the ``--no-relax`` option."""
+    options = generate_options('--no-relax', '-k', '2', '2', '2')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert 'relax' not in inputs
+    assert inputs.scf.kpoints.get_kpoints_mesh() == ([2, 2, 2], [0.0, 0.0, 0.0])
+
+
+def test_command_hubbard_qpoints_mesh(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with an explicit q-points mesh."""
+    options = generate_options('-q', '3', '3', '3')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+
+    assert 'qpoints_distance' not in inputs.hubbard
+    assert inputs.hubbard.qpoints.get_kpoints_mesh() == ([3, 3, 3], [0.0, 0.0, 0.0])
+
+
+def test_command_hubbard_pseudo_family(run_cli_process_launch_command, generate_options, launched_processes, sssp):
+    """Test invoking the workflow launch command with the ``--pseudo-family`` option."""
+    options = generate_options('-F', sssp.label)
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    pseudos = inputs.scf.pw.pseudos
+
+    assert sorted(pseudos.keys()) == ['Co', 'Li', 'O']
+    assert all(pseudo.uuid in [node.uuid for node in sssp.nodes] for pseudo in pseudos.values())
+
+
+def test_command_hubbard_overrides(
+    run_cli_process_launch_command, generate_options, filepath_cli_fixtures, launched_processes
+):
+    """Test invoking the workflow launch command with the ``--overrides`` option."""
+    filepath_overrides = Path(filepath_cli_fixtures, 'overrides', 'hubbard.yaml')
+    options = generate_options('-o', str(filepath_overrides))
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.tolerance_onsite.value == 0.5
+    assert inputs.max_iterations.value == 3
+    assert inputs.scf.kpoints_distance.value == 1.0
+
+
+def test_command_hubbard_electronic_type(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with the ``--electronic-type`` option."""
+    options = generate_options('--electronic-type', 'insulator')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    parameters = launched_processes[0].inputs.scf.pw.parameters.get_dict()
+    assert parameters['SYSTEM']['occupations'] == 'fixed'
+    assert 'smearing' not in parameters['SYSTEM']
+
+
+def test_command_hubbard_spin_type(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with the ``--spin-type`` option."""
+    options = generate_options('--spin-type', 'collinear')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    parameters = launched_processes[0].inputs.scf.pw.parameters.get_dict()
+    assert parameters['SYSTEM']['nspin'] == 2
+    assert 'starting_magnetization' in parameters['SYSTEM']
+
+
+def test_command_hubbard_relax_type(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with the ``--relax-type`` option."""
+    options = generate_options('--relax-type', 'positions')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.relax.base_relax.pw.parameters['CONTROL']['calculation'] == 'relax'
+    assert 'CELL' not in inputs.relax.base_relax.pw.parameters.get_dict()
+
+
+def test_command_hubbard_meta_convergence(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with the ``--no-meta-convergence`` option."""
+    options = generate_options('--no-meta-convergence')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    assert launched_processes[0].inputs.meta_convergence.value is False
+
+
+def test_command_hubbard_clean_workdir(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with the ``--no-clean-workdir`` option."""
+    options = generate_options('--no-clean-workdir')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    assert launched_processes[0].inputs.clean_workdir.value is False
+
+
+def test_command_hubbard_parallelization(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with the parallelization options."""
+    options = generate_options('--no-parallelize-atoms', '--no-parallelize-qpoints')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.hubbard.parallelize_atoms.value is False
+    assert inputs.hubbard.parallelize_qpoints.value is False
+
+
+def test_command_hubbard_parallelization_implied(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test that disabling the atom parallelization implies disabling the q-point parallelization."""
+    options = generate_options('--no-parallelize-atoms')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+    assert inputs.hubbard.parallelize_atoms.value is False
+    assert inputs.hubbard.parallelize_qpoints.value is False
+
+
+def test_command_hubbard_parallelization_invalid(run_cli_command, generate_options):
+    """Test that q-point parallelization cannot be requested without atom parallelization."""
+    options = generate_options('--no-parallelize-atoms', '--parallelize-qpoints')
+
+    result = run_cli_command(launch_workflow, options=options, raises=True)
+    assert '--parallelize-qpoints' in result.output
+
+
+def test_command_hubbard_options(run_cli_process_launch_command, generate_options, launched_processes):
+    """Test invoking the workflow launch command with the computational resource options."""
+    options = generate_options('-m', '4', '-w', '900', '--without-mpi')
+    run_cli_process_launch_command(launch_workflow, options=options)
+
+    inputs = launched_processes[0].inputs
+
+    for metadata in (
+        inputs.scf.pw.metadata,
+        inputs.relax.base_relax.pw.metadata,
+        inputs.relax.base_init_relax.pw.metadata,
+        inputs.hubbard.hp.metadata,
+    ):
+        assert metadata['options']['resources']['num_machines'] == 4
+        assert metadata['options']['max_wallclock_seconds'] == 900
+        assert metadata['options']['withmpi'] is False
+
+
+def test_command_hubbard_invalid_protocol(run_cli_command, generate_options):
+    """Test invoking the workflow launch command with an invalid protocol."""
+    options = generate_options()
+    options[options.index('-p') + 1] = 'not-a-protocol'
+
+    result = run_cli_command(launch_workflow, options=options, raises=True)
+    assert 'not-a-protocol' in result.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -522,10 +522,14 @@ def generate_inputs_hubbard(generate_inputs_pw, generate_inputs_hp, generate_hub
             'meta_convergence': Bool(True),
             'hubbard_structure': hubbard_structure,
             'relax': {
-                'base': {
+                'base_init_relax': {
                     'pw': inputs_pw,
                     'kpoints': kpoints,
-                }
+                },
+                'base_relax': {
+                    'pw': inputs_pw,
+                    'kpoints': kpoints,
+                },
             },
             'scf': {
                 'pw': inputs_pw,

--- a/tests/workflows/protocols/test_hubbard.py
+++ b/tests/workflows/protocols/test_hubbard.py
@@ -72,4 +72,5 @@ def test_options(fixture_code, generate_hubbard_structure):
 
     assert builder.hubbard.hp.metadata['options']['queue_name'] == queue_name
     assert builder.scf.pw.metadata['options']['queue_name'] == queue_name
-    assert builder.relax.base.pw.metadata['options']['queue_name'] == queue_name
+    assert builder.relax.base_relax.pw.metadata['options']['queue_name'] == queue_name
+    assert builder.relax.base_init_relax.pw.metadata['options']['queue_name'] == queue_name

--- a/tests/workflows/protocols/test_hubbard/test_default.yml
+++ b/tests/workflows/protocols/test_hubbard/test_default.yml
@@ -31,7 +31,45 @@ radial_analysis:
   radius_max: 10.0
   thr: 0.01
 relax:
-  base:
+  base_init_relax:
+    kpoints_distance: 0.3
+    kpoints_force_parity: false
+    max_iterations: 5
+    pw:
+      code: test.quantumespresso.pw@localhost
+      metadata:
+        options:
+          max_wallclock_seconds: 43200
+          resources:
+            num_machines: 1
+            num_mpiprocs_per_machine: 1
+          withmpi: true
+      parameters:
+        CELL:
+          cell_dofree: all
+          press_conv_thr: 2
+        CONTROL:
+          calculation: vc-relax
+          etot_conv_thr: 0.004
+          forc_conv_thr: 0.005
+          tprnfor: true
+          tstress: true
+        ELECTRONS:
+          conv_thr: 4.0e-06
+          electron_maxstep: 80
+          mixing_beta: 0.4
+        SYSTEM:
+          degauss: 0.02
+          ecutrho: 240.0
+          ecutwfc: 30.0
+          nosym: false
+          occupations: smearing
+          smearing: cold
+      pseudos:
+        Co: Co<md5=04edd96127402ab6ffc358660b52a2db>
+        Li: Li<md5=90ac4658c7606c7ad16e40ce66db5a86>
+        O: O<md5=721f9895631356f7d4610e60de16fd63>
+  base_relax:
     kpoints_distance: 0.15
     kpoints_force_parity: false
     max_iterations: 5
@@ -71,7 +109,6 @@ relax:
         O: O<md5=721f9895631356f7d4610e60de16fd63>
   max_meta_convergence_iterations: 5
   meta_convergence: true
-  volume_convergence: 0.02
 scf:
   kpoints_distance: 0.4
   kpoints_force_parity: false

--- a/tests/workflows/test_hubbard.py
+++ b/tests/workflows/test_hubbard.py
@@ -167,6 +167,43 @@ def test_magnetic_setup(generate_workchain_hubbard, generate_inputs_hubbard):
 
 
 @pytest.mark.usefixtures('aiida_profile')
+def test_relax_inputs(generate_workchain_hubbard, generate_inputs_hubbard):
+    """Test `SelfConsistentHubbardWorkChain.get_inputs` for the `relax` namespace.
+
+    Both the `base_init_relax` and the `base_relax` namespaces must receive the pseudos
+    of the current structure and the current starting magnetization.
+    """
+    from aiida_hubbard.workflows.hubbard import PwRelaxWorkChain
+
+    inputs = AttributeDict(generate_inputs_hubbard())
+    inputs.scf.pw.parameters['SYSTEM'].update({'nspin': 2, 'starting_magnetization': {'Co': 0.5}})
+    process = generate_workchain_hubbard(inputs=inputs)
+    process.setup()
+
+    relax_inputs = process.get_inputs(PwRelaxWorkChain, 'relax')
+
+    assert relax_inputs.structure == process.ctx.current_hubbard_structure
+
+    kind_names = sorted(process.ctx.current_hubbard_structure.get_kind_names())
+    for namespace in ('base_init_relax', 'base_relax'):
+        assert namespace in relax_inputs
+        assert sorted(relax_inputs[namespace].pw.pseudos.keys()) == kind_names
+        parameters = relax_inputs[namespace].pw.parameters.get_dict()
+        assert parameters['SYSTEM']['starting_magnetization'] == {'Co': 0.5}
+
+    # The `base_init_relax` namespace is optional and can be left out.
+    inputs = AttributeDict(generate_inputs_hubbard())
+    inputs.relax.pop('base_init_relax')
+    process = generate_workchain_hubbard(inputs=inputs)
+    process.setup()
+
+    relax_inputs = process.get_inputs(PwRelaxWorkChain, 'relax')
+
+    assert 'base_init_relax' not in relax_inputs
+    assert sorted(relax_inputs.base_relax.pw.pseudos.keys()) == kind_names
+
+
+@pytest.mark.usefixtures('aiida_profile')
 def test_skip_relax_iterations(generate_workchain_hubbard, generate_inputs_hubbard, generate_hp_workchain_node):
     """Test `SelfConsistentHubbardWorkChain` when skipping the first relax iterations."""
     inputs = generate_inputs_hubbard()


### PR DESCRIPTION
Update the plugin to `aiida-quantumespresso` v5.0, which has two breaking changes affecting `aiida-hubbard`:

* `PwRelaxWorkChain` was reworked: the `base` namespace is renamed to `base_relax`, the `base_final_scf` namespace and the final SCF step are removed, the optional `base_init_relax` pre-relaxation is added, and the `volume_convergence` input is gone. The `SelfConsistentHubbardWorkChain` exposure, protocol builder and `get_inputs` are updated accordingly. Unlike the old final SCF (which was wasted time, since an SCF follows anyway in the cycle), the new initial loose relaxation is a useful optimization, so it is exposed and supported: `get_inputs` feeds it the current pseudos and starting magnetization at every iteration, like the main `base_relax`.
* The private helper `_lowercase_dict` was removed from `aiida_quantumespresso.calculations`; it is now defined locally in `calculations/hp.py` via the still-available `_case_transform_dict`.

The requirements are updated to `aiida-quantumespresso~=5.0` and `aiida-core~=2.8` (required by aiida-qe v5.0). The test fixtures and protocol regression data are updated to the new `relax.base_init_relax`/`relax.base_relax` input structure, with a new test covering the relax input preparation. The self-consistent tutorial notebook is re-executed on v5: the initial relaxation lets the main relax converge in a single meta-convergence iteration, with the final U(Co-3d) unchanged (7.861 eV). Beware that overrides using the old `relax.base`/`relax.base_final_scf` keys are silently ignored by the v5 protocol builder (hence, make sure to update current scripts!).